### PR TITLE
Fixed: Bug where components could not be found via TryGetComponentById after calling TrySetUniqueId

### DIFF
--- a/Runtime/Scripts/Core/Components/UxrComponent.cs
+++ b/Runtime/Scripts/Core/Components/UxrComponent.cs
@@ -206,7 +206,7 @@ namespace UltimateXR.Core.Components
 
                 OnUniqueIdChanging(UniqueId, newUniqueId);
                 UniqueId = newUniqueId;
-                s_componentsById.Add(UniqueId,this);
+                s_componentsById.Add(UniqueId, this);
                 OnUniqueIdChanged(UniqueId, newUniqueId);
                 return true;
             }

--- a/Runtime/Scripts/Core/Components/UxrComponent.cs
+++ b/Runtime/Scripts/Core/Components/UxrComponent.cs
@@ -206,6 +206,7 @@ namespace UltimateXR.Core.Components
 
                 OnUniqueIdChanging(UniqueId, newUniqueId);
                 UniqueId = newUniqueId;
+                s_componentsById.Add(UniqueId,this);
                 OnUniqueIdChanged(UniqueId, newUniqueId);
                 return true;
             }

--- a/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
+++ b/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
@@ -187,7 +187,7 @@ namespace UltimateXR.Devices.Integrations
                 return;
             }
 
-            if (!inputDevice.TryGetHapticCapabilities(out HapticCapabilities hapticCapabilities))
+            if (!inputDevice.TryGetHapticCapabilities(out HapticCapabilities hapticCapabilities) || hapticCapabilities.numChannels == 0)
             {
                 return;
             }
@@ -250,7 +250,7 @@ namespace UltimateXR.Devices.Integrations
                 return;
             }
 
-            if (!inputDevice.TryGetHapticCapabilities(out HapticCapabilities hapticCapabilities))
+            if (!inputDevice.TryGetHapticCapabilities(out HapticCapabilities hapticCapabilities) || hapticCapabilities.numChannels == 0)
             {
                 return;
             }
@@ -262,15 +262,12 @@ namespace UltimateXR.Devices.Integrations
             {
                 if (handSide == UxrHandSide.Left)
                 {
-                    if(hapticCapabilities.numChannels > 0)
-                        _leftHapticChannel = (_leftHapticChannel + 1) % hapticCapabilities.numChannels;
-
+                    _leftHapticChannel = (_leftHapticChannel + 1) % hapticCapabilities.numChannels;
                     channel            = _leftHapticChannel;
                 }
                 else
                 {
-                    if (hapticCapabilities.numChannels > 0)
-                        _rightHapticChannel = (_rightHapticChannel + 1) % hapticCapabilities.numChannels;
+                    _rightHapticChannel = (_rightHapticChannel + 1) % hapticCapabilities.numChannels;
                     channel             = _rightHapticChannel;
                 }
             }

--- a/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
+++ b/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
@@ -262,12 +262,15 @@ namespace UltimateXR.Devices.Integrations
             {
                 if (handSide == UxrHandSide.Left)
                 {
-                    _leftHapticChannel = (_leftHapticChannel + 1) % hapticCapabilities.numChannels;
+                    if(hapticCapabilities.numChannels > 0)
+                        _leftHapticChannel = (_leftHapticChannel + 1) % hapticCapabilities.numChannels;
+
                     channel            = _leftHapticChannel;
                 }
                 else
                 {
-                    _rightHapticChannel = (_rightHapticChannel + 1) % hapticCapabilities.numChannels;
+                    if (hapticCapabilities.numChannels > 0)
+                        _rightHapticChannel = (_rightHapticChannel + 1) % hapticCapabilities.numChannels;
                     channel             = _rightHapticChannel;
                 }
             }


### PR DESCRIPTION
Calling TrySetUniqueId now adds the new UniqueID to the s_componetsById Dictionary so that the Component can be found when calling UxrComponent.TryGetComponentById() with the new UniqueID.