### PR TITLE
adds option 'Laser Pointers and Finger Tips' for UI-Interactions

### DIFF
--- a/Runtime/Scripts/UI/UnityInputModule/UxrCanvas.cs
+++ b/Runtime/Scripts/UI/UnityInputModule/UxrCanvas.cs
@@ -21,11 +21,11 @@ namespace UltimateXR.UI.UnityInputModule
         #region Inspector Properties/Serialized Fields
 
         [SerializeField] protected UxrInteractionType _interactionType;
-        [SerializeField] protected float              _fingerTipMinHoverDistance = UxrFingerTipRaycaster.FingerTipMinHoverDistanceDefault;
-        [SerializeField] protected bool               _autoEnableLaserPointer;
-        [SerializeField] protected float              _autoEnableDistance = 5.0f;
-        [SerializeField] protected bool               _allowLeftHand      = true;
-        [SerializeField] protected bool               _allowRightHand     = true;
+        [SerializeField] protected float _fingerTipMinHoverDistance = UxrFingerTipRaycaster.FingerTipMinHoverDistanceDefault;
+        [SerializeField] protected bool _autoEnableLaserPointer;
+        [SerializeField] protected float _autoEnableDistance = 5.0f;
+        [SerializeField] protected bool _allowLeftHand = true;
+        [SerializeField] protected bool _allowRightHand = true;
 
         #endregion
 
@@ -156,11 +156,17 @@ namespace UltimateXR.UI.UnityInputModule
 
             if (_interactionType == UxrInteractionType.FingerTips)
             {
-                _newRaycasterFingerTips                           = GetOrAddRaycaster<UxrFingerTipRaycaster>(_oldRaycaster);
+                _newRaycasterFingerTips = GetOrAddRaycaster<UxrFingerTipRaycaster>(_oldRaycaster);
                 _newRaycasterFingerTips.FingerTipMinHoverDistance = _fingerTipMinHoverDistance;
             }
             else if (_interactionType == UxrInteractionType.LaserPointers)
             {
+                _newRaycasterLaserPointer = GetOrAddRaycaster<UxrLaserPointerRaycaster>(_oldRaycaster);
+            }
+            else if (_interactionType == UxrInteractionType.LaserPointersAndFingerTips)
+            {
+                _newRaycasterFingerTips = GetOrAddRaycaster<UxrFingerTipRaycaster>(_oldRaycaster);
+                _newRaycasterFingerTips.FingerTipMinHoverDistance = _fingerTipMinHoverDistance;
                 _newRaycasterLaserPointer = GetOrAddRaycaster<UxrLaserPointerRaycaster>(_oldRaycaster);
             }
         }
@@ -174,8 +180,8 @@ namespace UltimateXR.UI.UnityInputModule
         private T GetOrAddRaycaster<T>(GraphicRaycaster oldRaycaster) where T : GraphicRaycaster
         {
             bool copyParameters = UnityCanvas.GetComponent<T>() == null;
-            T    rayCaster      = UnityCanvas.GetOrAddComponent<T>();
-            
+            T rayCaster = UnityCanvas.GetOrAddComponent<T>();
+
             rayCaster.enabled = true;
 
             if (oldRaycaster && rayCaster)
@@ -183,10 +189,10 @@ namespace UltimateXR.UI.UnityInputModule
                 if (copyParameters)
                 {
                     rayCaster.ignoreReversedGraphics = oldRaycaster.ignoreReversedGraphics;
-                    rayCaster.blockingObjects        = GraphicRaycaster.BlockingObjects.All;
-                    rayCaster.blockingMask           = oldRaycaster.blockingMask;
+                    rayCaster.blockingObjects = GraphicRaycaster.BlockingObjects.All;
+                    rayCaster.blockingMask = oldRaycaster.blockingMask;
                 }
-                
+
                 oldRaycaster.enabled = false;
             }
 
@@ -218,8 +224,8 @@ namespace UltimateXR.UI.UnityInputModule
 
         #region Private Types & Data
 
-        private GraphicRaycaster         _oldRaycaster;
-        private UxrFingerTipRaycaster    _newRaycasterFingerTips;
+        private GraphicRaycaster _oldRaycaster;
+        private UxrFingerTipRaycaster _newRaycasterFingerTips;
         private UxrLaserPointerRaycaster _newRaycasterLaserPointer;
 
         #endregion

--- a/Runtime/Scripts/UI/UnityInputModule/UxrInteractionType.cs
+++ b/Runtime/Scripts/UI/UnityInputModule/UxrInteractionType.cs
@@ -21,6 +21,11 @@ namespace UltimateXR.UI.UnityInputModule
         /// <summary>
         ///     Interaction using <see cref="UxrLaserPointer" /> components from a distance.
         /// </summary>
-        LaserPointers
+        LaserPointers,
+
+        /// <summary>
+        ///     Interaction using LaserPointer and FingerTip components.
+        /// </summary>
+        LaserPointersAndFingerTips
     }
 }


### PR DESCRIPTION
extends the existing options
- Finger Tips
- Laser Pointers

with
- Laser Pointers and Finger Tips

why
- without this third option i wasn't able to configure a setup that uses both at the same time. Always one did cancel out the other.

missing
- some optional parameters are not displayed in the editor while 'Laser Pointers and Finger Tips' is selected. I've no clue how to display them (Finger Tip Min Hover Distance, Auto Enable Laser Pointer etc.) 