### PR TITLE
Add support for Meta Quest 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for Meta Quest 3.
 - Add support for Magic Leap 2.
 - Add support for Unity UI input on the screen and UltimateXR UI input in VR at
   the same time.

--- a/Runtime/Prefabs/Avatars/BigHandsAvatar_BRP.prefab
+++ b/Runtime/Prefabs/Avatars/BigHandsAvatar_BRP.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 0a3080475033ed843b3282ba8e51cad5, type: 2}
+    - target: {fileID: 69629519940409446, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 131211750974746253, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -123,6 +128,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: f4e65bb3abeeca4409f24f1c6c9a79f4, type: 2}
+    - target: {fileID: 544788197833730039, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 559928391260141850, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -133,6 +143,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27c7eda1954669e4b940666ffbbcb8b7, type: 2}
+    - target: {fileID: 612913894251562005, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 705176696186739924, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -248,6 +263,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e20b9633d10848c4392bf51cb69fa6bb, type: 2}
+    - target: {fileID: 2118754151856851427, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 2125229348584825227, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -518,6 +538,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 0a3080475033ed843b3282ba8e51cad5, type: 2}
+    - target: {fileID: 5060378933564120015, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 5163577682426966294, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -696,12 +721,12 @@ PrefabInstance:
     - target: {fileID: 5650837157645551361, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5674541866823645512, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5747487085545151735, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
@@ -728,6 +753,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 6030685488626646327, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 6045177740115343286, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -1048,11 +1078,21 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27c7eda1954669e4b940666ffbbcb8b7, type: 2}
+    - target: {fileID: 8855062332212243741, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 8973413973586983196, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 9c9c6af7156888b4797ee17f93f16970, type: 2}
+    - target: {fileID: 9088825715043149952, guid: dc011efb41f2d4a419389aefb4b4270d,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 9107505143480928260, guid: dc011efb41f2d4a419389aefb4b4270d,
         type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Runtime/Prefabs/Avatars/CyborgAvatar_BRP.prefab
+++ b/Runtime/Prefabs/Avatars/CyborgAvatar_BRP.prefab
@@ -37,6 +37,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e20b9633d10848c4392bf51cb69fa6bb, type: 2}
+    - target: {fileID: 379274493887615850, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 385747562568907522, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -122,6 +127,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27c7eda1954669e4b940666ffbbcb8b7, type: 2}
+    - target: {fileID: 1199547913907363484, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 1291809547620337245, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -152,6 +162,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 0a3080475033ed843b3282ba8e51cad5, type: 2}
+    - target: {fileID: 1788905579766055663, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 1799565471684064832, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -197,6 +212,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: f4e65bb3abeeca4409f24f1c6c9a79f4, type: 2}
+    - target: {fileID: 2282021482646355326, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 2295449583875615353, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -622,6 +642,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 5446378035642623934, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 5458582878496033345, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -825,12 +850,12 @@ PrefabInstance:
     - target: {fileID: 6219446883162316168, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6261167088146883521, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6334042971131217534, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
@@ -873,6 +898,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 0a3080475033ed843b3282ba8e51cad5, type: 2}
+    - target: {fileID: 6781915660096356678, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 6885037373360958367, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -993,6 +1023,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
+    - target: {fileID: 7117842239358089108, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 7127921105774901673, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -1003,6 +1038,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 9c9c6af7156888b4797ee17f93f16970, type: 2}
+    - target: {fileID: 7351520960909111817, guid: e7468ec6b7af89c4d94d451ec3c1807b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ad322e721b4fae841a0f3eb235db1e2f, type: 2}
     - target: {fileID: 7368025487668351629, guid: e7468ec6b7af89c4d94d451ec3c1807b,
         type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Runtime/Prefabs/Avatars/SmallHandsAvatar_BRP.prefab
+++ b/Runtime/Prefabs/Avatars/SmallHandsAvatar_BRP.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     - target: {fileID: 76263981690167358, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 83297221916827509, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
@@ -167,6 +167,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27c7eda1954669e4b940666ffbbcb8b7, type: 2}
+    - target: {fileID: 2371609891226181950, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 2522472309943230293, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -292,6 +297,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27e60674c24c4fe48bb59b7e054b5167, type: 2}
+    - target: {fileID: 3687952606020387887, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 3695510933615478258, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -307,6 +317,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: f4e65bb3abeeca4409f24f1c6c9a79f4, type: 2}
+    - target: {fileID: 3814088490906428471, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 3866770185385936685, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -440,7 +455,7 @@ PrefabInstance:
     - target: {fileID: 4590891493005708415, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: _selectedRenderPipeline
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4740302164361893345, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
@@ -493,6 +508,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2100000, guid: 0a3080475033ed843b3282ba8e51cad5, type: 2}
     - target: {fileID: 5009609740005678619, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
+    - target: {fileID: 5045934406505777142, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -717,6 +737,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e20b9633d10848c4392bf51cb69fa6bb, type: 2}
+    - target: {fileID: 5899740287353752434, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 5974181162225769025, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -732,6 +757,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 6454771832729785409, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 6541680529158159008, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -1028,6 +1058,16 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 27c7eda1954669e4b940666ffbbcb8b7, type: 2}
+    - target: {fileID: 8628410103975013983, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
+    - target: {fileID: 8631707842726169978, guid: 7195d091dac462e4db9ba0793d9a6727,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1e6af80e259af224a94a9586efd5844f, type: 2}
     - target: {fileID: 8941768585410284709, guid: 7195d091dac462e4db9ba0793d9a6727,
         type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3.meta
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df59478e1081bab429bf047e2f56688f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_BRP.prefab
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_BRP.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &539128993004112985
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 966369222676206241, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 1188802913679534755, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2230841170513511138, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 2433576852887608440, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 4680093838270318522, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 5385756840750099578, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 6870409173723787014, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 7850569591709463420, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest2Left_BRP
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_BRP.prefab.meta
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_BRP.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 255791cacd2861344a0d262739b4d56c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_URP.prefab
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_URP.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2661975718789783555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3592701107161174054}
+  m_Layer: 0
+  m_Name: Forward
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3592701107161174054
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2661975718789783555}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1594966257726824121}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7850569591709463420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1594966257726824121}
+  - component: {fileID: 2168958278646429756}
+  m_Layer: 0
+  m_Name: MetaTouchQuest3Left_URP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1594966257726824121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7850569591709463420}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3592701107161174054}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2168958278646429756
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7850569591709463420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _needsBothHands: 0
+  _handSide: 0
+  _controllerHand: {fileID: 0}
+  _controllerHandLeft: {fileID: 0}
+  _controllerHandRight: {fileID: 0}
+  _forward: {fileID: 3592701107161174054}
+  _controllerElements: []

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_URP.prefab.meta
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Left_URP.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8244bc36b1d379643b2924571e4c6551
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_BRP.prefab
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_BRP.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1755753036789180914
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 123578103027936240, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 857358314630387516, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 2005349881845887274, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 3032437294221186659, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4956119863783217206, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 6279430623672321459, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 8932223116229830773, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: de886fbb3e6af5142a06b01553c61d13, type: 2}
+    - target: {fileID: 9100977399721758085, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest2Right_BRP
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_BRP.prefab.meta
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_BRP.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed506054ef4f1a04a88de92c24dfe986
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_URP.prefab
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_URP.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2628216675343912401
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1646779209904500725}
+  m_Layer: 0
+  m_Name: Forward
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1646779209904500725
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2628216675343912401}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4731214129627339279}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9100977399721758085
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4731214129627339279}
+  - component: {fileID: 518162736366091525}
+  m_Layer: 0
+  m_Name: MetaTouchQuest3Right_URP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4731214129627339279
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9100977399721758085}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1646779209904500725}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &518162736366091525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9100977399721758085}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _needsBothHands: 0
+  _handSide: 1
+  _controllerHand: {fileID: 0}
+  _controllerHandLeft: {fileID: 0}
+  _controllerHandRight: {fileID: 0}
+  _forward: {fileID: 1646779209904500725}
+  _controllerElements: []

--- a/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_URP.prefab.meta
+++ b/Runtime/Prefabs/Devices/MetaTouchQuest3/MetaTouchQuest3Right_URP.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d02b3151a5cba244299ff36e1b341b0e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/HandIntegrations/BigHandsIntegration.prefab
+++ b/Runtime/Prefabs/HandIntegrations/BigHandsIntegration.prefab
@@ -79,7 +79,7 @@ Transform:
   m_Children:
   - {fileID: 5689366600098749271}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &923010974289560737
 GameObject:
@@ -279,7 +279,7 @@ Transform:
   m_Children:
   - {fileID: 5024159597714144136}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 10
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &1350892948486383470
 GameObject:
@@ -375,7 +375,7 @@ Transform:
   m_Children:
   - {fileID: 1027021662347591207}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 9
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1655297883103039390
 GameObject:
@@ -390,6 +390,10 @@ GameObject:
   - component: {fileID: 4147247934415372625}
   - component: {fileID: 1841659159450150915}
   - component: {fileID: 7242263623341472858}
+  - component: {fileID: 3578578708654043517}
+  - component: {fileID: 422649948921321604}
+  - component: {fileID: 1389755949592648307}
+  - component: {fileID: 2778494389986017211}
   m_Layer: 0
   m_Name: Meta
   m_TagString: Untagged
@@ -410,7 +414,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8532458878888819050
 MonoBehaviour:
@@ -493,6 +497,87 @@ MonoBehaviour:
   _littleCurlAmount: 60
   _thumbCurlAmount: 60
   _thumbSpreadAmount: 30
+--- !u!114 &3578578708654043517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1655297883103039390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cc855f608e72a745b7a79e8ca93ba67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
+  _leftHandSensor: {fileID: 7050033996725133422}
+  _rightHandSensor: {fileID: 3404765203270880376}
+  _updateAvatarLeftHand: 1
+  _updateAvatarRightHand: 1
+  _smoothPosition: 0
+  _smoothRotation: 0
+--- !u!114 &422649948921321604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1655297883103039390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd07cb58266720f478deb9264c45c614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leftController: {fileID: 142411623374878869}
+  _rightController: {fileID: 3240849616094887486}
+  _controller: {fileID: 0}
+  _enableObjectListLeft: []
+  _enableObjectListRight: []
+  _enableObjectList: []
+--- !u!114 &1389755949592648307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1655297883103039390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07ea441b9add1fd4fb72713dd14725cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
+  _leftHandSensor: {fileID: 2821985838646307844}
+  _rightHandSensor: {fileID: 4806222123587879980}
+  _updateAvatarLeftHand: 1
+  _updateAvatarRightHand: 1
+  _smoothPosition: 0
+  _smoothRotation: 0
+--- !u!114 &2778494389986017211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1655297883103039390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0acc555071f36c4fb74251d9a25c5ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leftController: {fileID: 4370221605869430038}
+  _rightController: {fileID: 3128767737442454203}
+  _controller: {fileID: 0}
+  _enableObjectListLeft: []
+  _enableObjectListRight: []
+  _enableObjectList: []
+  _openHandPoseName: 
+  _indexCurlAmount: 60
+  _middleCurlAmount: 60
+  _ringCurlAmount: 60
+  _littleCurlAmount: 60
+  _thumbCurlAmount: 60
+  _thumbSpreadAmount: 30
 --- !u!1 &1682534057263748306
 GameObject:
   m_ObjectHideFlags: 0
@@ -524,7 +609,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: -1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9133783278409568517
 MonoBehaviour:
@@ -593,7 +678,7 @@ Transform:
   m_Children:
   - {fileID: 3321089477655472406}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 9
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 5.956, y: -60.022, z: -446.575}
 --- !u!1 &2523822421854163653
 GameObject:
@@ -625,7 +710,7 @@ Transform:
   m_Children:
   - {fileID: 4757642101461030966}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 8
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &2580474687246998895
 GameObject:
@@ -657,8 +742,40 @@ Transform:
   m_Children:
   - {fileID: 4459583609491229790}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 11
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 1.603, y: -60.283, z: -86.592}
+--- !u!1 &2940099708013657220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4806222123587879980}
+  m_Layer: 0
+  m_Name: SensorRightMetaTouchQuest3SteamVR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4806222123587879980
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2940099708013657220}
+  m_LocalRotation: {x: -0.20776159, y: 0.09370892, z: 0.63461757, w: -0.73845404}
+  m_LocalPosition: {x: -0.13751689, y: 0.00735256, z: 0.097285904}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7922915598243933617}
+  m_Father: {fileID: 4171102772956879574}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &3132861317275176340
 GameObject:
   m_ObjectHideFlags: 0
@@ -690,7 +807,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2260535237899372711
 MonoBehaviour:
@@ -766,7 +883,7 @@ Transform:
   m_Children:
   - {fileID: 1269254892640704105}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &3446316109495972681
 GameObject:
@@ -797,7 +914,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3517219619167555630
 GameObject:
@@ -961,6 +1078,38 @@ MonoBehaviour:
   _enableObjectListLeft: []
   _enableObjectListRight: []
   _enableObjectList: []
+--- !u!1 &3592431453578873305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5262386689759129678}
+  m_Layer: 0
+  m_Name: SensorLeftMetaTouchQuest3SteamVR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5262386689759129678
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3592431453578873305}
+  m_LocalRotation: {x: 0.093708925, y: -0.20776157, z: -0.73845404, w: 0.6346175}
+  m_LocalPosition: {x: -0.13751689, y: -0.0073525608, z: 0.0972859}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3791432928286983059}
+  m_Father: {fileID: 4171102772093747027}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &4015923435439793466
 GameObject:
   m_ObjectHideFlags: 0
@@ -991,7 +1140,7 @@ Transform:
   m_Children:
   - {fileID: 7477928993898623395}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4103885657867985575
 GameObject:
@@ -1023,7 +1172,7 @@ Transform:
   m_Children:
   - {fileID: 1484898669294420845}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: -1
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 2.835, y: -66.649, z: -88.791}
 --- !u!1 &4171102771577861390
 GameObject:
@@ -1055,7 +1204,7 @@ Transform:
   m_Children:
   - {fileID: 7386139242445085141}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 13
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: -7.6920004, y: -46.296, z: -97.33301}
 --- !u!1 &4171102771787782017
 GameObject:
@@ -1087,7 +1236,7 @@ Transform:
   m_Children:
   - {fileID: 6521199125747666492}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 13
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 7.7400002, y: -46.818, z: -446.558}
 --- !u!1 &4171102771955918066
 GameObject:
@@ -1190,6 +1339,8 @@ Transform:
   - {fileID: 3657923893286438043}
   - {fileID: 4208149788106692293}
   - {fileID: 2821985838646307844}
+  - {fileID: 7050033996725133422}
+  - {fileID: 5262386689759129678}
   - {fileID: 4171102773428178843}
   - {fileID: 5547079642152758336}
   - {fileID: 1060513094057905011}
@@ -1333,6 +1484,8 @@ Transform:
   - {fileID: 1713394206075963707}
   - {fileID: 149411600586214224}
   - {fileID: 8020760588509249827}
+  - {fileID: 3404765203270880376}
+  - {fileID: 4806222123587879980}
   - {fileID: 4171102773436849566}
   - {fileID: 4378509195466400251}
   - {fileID: 8683238100874698455}
@@ -1373,7 +1526,7 @@ Transform:
   m_Children:
   - {fileID: 8670577416213706627}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 12
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 7.102, y: -49.612003, z: -86.247}
 --- !u!1 &4171102773376192593
 GameObject:
@@ -1405,7 +1558,7 @@ Transform:
   m_Children:
   - {fileID: 1368918004222371822}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 12
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4171102773387943279
 GameObject:
@@ -1468,7 +1621,7 @@ Transform:
   m_Children:
   - {fileID: 1775055263810432583}
   m_Father: {fileID: 4171102772093747027}
-  m_RootOrder: 7
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: -5.9560003, y: -60.022003, z: -93.425}
 --- !u!1 &4171102773436849565
 GameObject:
@@ -1500,7 +1653,7 @@ Transform:
   m_Children:
   - {fileID: 4729000470985783860}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 7
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 5.9560003, y: -60.022003, z: -446.575}
 --- !u!1 &4698113205709874292
 GameObject:
@@ -1573,6 +1726,38 @@ MonoBehaviour:
   _enableObjectListRight: []
   _enableObjectList: []
   _joystickDeadZone: 0.15
+--- !u!1 &4772068192404924788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7050033996725133422}
+  m_Layer: 0
+  m_Name: SensorLeftMetaTouchQuest3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7050033996725133422
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4772068192404924788}
+  m_LocalRotation: {x: 0.33274636, y: -0.3752284, z: -0.64729697, w: 0.57401234}
+  m_LocalPosition: {x: -0.12119139, y: -0.026985772, z: 0.04970215}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 703185865176981008}
+  m_Father: {fileID: 4171102772093747027}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4824311590596681509
 GameObject:
   m_ObjectHideFlags: 0
@@ -1723,7 +1908,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7827896309404613509
 MonoBehaviour:
@@ -1918,7 +2103,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2664535392226076555
 MonoBehaviour:
@@ -2092,6 +2277,38 @@ Transform:
   m_Father: {fileID: 2690326291321492927}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7053105699811987201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3404765203270880376}
+  m_Layer: 0
+  m_Name: SensorRightMetaTouchQuest3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3404765203270880376
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7053105699811987201}
+  m_LocalRotation: {x: -0.37522775, y: 0.33274478, z: 0.57401586, w: -0.6472951}
+  m_LocalPosition: {x: -0.12119139, y: 0.02698577, z: 0.04970215}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7665561845243386164}
+  m_Father: {fileID: 4171102772956879574}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 5.956, y: -60.022, z: -446.575}
 --- !u!1 &7312139014399454060
 GameObject:
   m_ObjectHideFlags: 0
@@ -2122,7 +2339,7 @@ Transform:
   m_Children:
   - {fileID: 8085127552405452350}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 10
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &8231590589311029401
 GameObject:
@@ -2154,7 +2371,7 @@ Transform:
   m_Children:
   - {fileID: 3743783497526393327}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 11
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 1.603, y: -60.283, z: -86.592}
 --- !u!1 &8573266508486301422
 GameObject:
@@ -2218,7 +2435,7 @@ Transform:
   m_Children:
   - {fileID: 2794318493382213131}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 8
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 169.169, y: 155.83301, z: 96.324}
 --- !u!1 &9061784337029679189
 GameObject:
@@ -2302,7 +2519,7 @@ Transform:
   m_Children:
   - {fileID: 7743368017229333725}
   m_Father: {fileID: 4171102772956879574}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 5.956, y: -60.022, z: -446.575}
 --- !u!1 &9145436978208824524
 GameObject:
@@ -2335,7 +2552,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2932619053151338739}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1289327559315359228
 MonoBehaviour:
@@ -2380,7 +2597,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4265126645085916260}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -2845,16 +3061,7 @@ PrefabInstance:
       value: 0.11381718
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &1534645383472097235 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 78431524817908848}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4540842523332753082 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -2872,7 +3079,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2676851959014731447}
     m_Modifications:
     - target: {fileID: 3648587437342829609, guid: b4ed1ff5000a874458e5227176282a5d,
@@ -2946,13 +3152,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 3648587437342829609, guid: b4ed1ff5000a874458e5227176282a5d,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7285691365885554640}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4ed1ff5000a874458e5227176282a5d, type: 3}
 --- !u!4 &3743783497526393327 stripped
 Transform:
@@ -2977,7 +3176,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1484898669294420845}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -3359,7 +3557,7 @@ PrefabInstance:
     - target: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
         type: 3}
@@ -3452,9 +3650,6 @@ PrefabInstance:
       value: -0.61582893
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &5246019524713785587 stripped
 MonoBehaviour:
@@ -3468,18 +3663,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8779131488263724305 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 230895143042487767}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &367184552900131792
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8480742919982509813}
     m_Modifications:
     - target: {fileID: 4905336985384385113, guid: 288a93c0145c91e42b6c0eaf63f1705c,
@@ -3553,13 +3741,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4905336985384385113, guid: 288a93c0145c91e42b6c0eaf63f1705c,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6277429000056855808}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 288a93c0145c91e42b6c0eaf63f1705c, type: 3}
 --- !u!4 &4687052697666617737 stripped
 Transform:
@@ -3584,7 +3765,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7070822845578666978}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -4054,9 +4234,6 @@ PrefabInstance:
       value: -0.5456949
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &5661274815603750096 stripped
 MonoBehaviour:
@@ -4070,18 +4247,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &9189810641016111410 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 389900487611124212}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &573702609812049994
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5689366600098749271}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -4551,9 +4721,6 @@ PrefabInstance:
       value: -0.61582893
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &5480850396705647982 stripped
 MonoBehaviour:
@@ -4567,18 +4734,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &9013887584232872076 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 573702609812049994}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &795962699595775614
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6521199125747666492}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -5028,16 +5188,7 @@ PrefabInstance:
       value: 0.11336796
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &2256674007353355741 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 795962699595775614}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3826132113688100020 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -5055,7 +5206,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3657923893286438043}
     m_Modifications:
     - target: {fileID: 1304256556020238828, guid: 829a78814902e734baf523f5584385ef,
@@ -5071,7 +5221,7 @@ PrefabInstance:
     - target: {fileID: 2256169275208995370, guid: 829a78814902e734baf523f5584385ef,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2256169275208995370, guid: 829a78814902e734baf523f5584385ef,
         type: 3}
@@ -5129,13 +5279,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5246019524713785587}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2256169275208995370, guid: 829a78814902e734baf523f5584385ef,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8779131488263724305}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 829a78814902e734baf523f5584385ef, type: 3}
 --- !u!4 &1484898669294420845 stripped
 Transform:
@@ -5160,7 +5303,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1368918004222371822}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -5610,16 +5752,7 @@ PrefabInstance:
       value: 0.07010599
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &1939866728374571307 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 1058706917144593032}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3504853214672257090 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -5637,7 +5770,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102773428178843}
     m_Modifications:
     - target: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
@@ -5676,13 +5808,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5848731115082976565}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6931878288838654167}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e468af470a9a84469c1fafd8a98d3aa, type: 3}
 --- !u!4 &1775055263810432583 stripped
 Transform:
@@ -5707,7 +5832,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4729000470985783860}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -6157,16 +6281,7 @@ PrefabInstance:
       value: 0.1164646
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &320890456431823628 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 1166022175158966447}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3331678306710723173 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -6184,7 +6299,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1775055263810432583}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -6654,9 +6768,6 @@ PrefabInstance:
       value: -0.7155714
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &5848731115082976565 stripped
 MonoBehaviour:
@@ -6670,18 +6781,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &6931878288838654167 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 1932900658222379025}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2100907364453947366
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1440190724186639468}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -7151,9 +7255,6 @@ PrefabInstance:
       value: -0.4799169
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &6259505418955565762 stripped
 MonoBehaviour:
@@ -7167,18 +7268,195 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &7477695455896887072 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
+--- !u!1001 &2296908987552596137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7050033996725133422}
+    m_Modifications:
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.0000000074505797
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8244bc36b1d379643b2924571e4c6551, type: 3}
+--- !u!114 &142411623374878869 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2168958278646429756, guid: 8244bc36b1d379643b2924571e4c6551,
     type: 3}
-  m_PrefabInstance: {fileID: 2100907364453947366}
+  m_PrefabInstance: {fileID: 2296908987552596137}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &703185865176981008 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 2296908987552596137}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2503884249544351018
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5262386689759129678}
+    m_Modifications:
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.010315016
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0034704842
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0528938
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9514167
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.29998213
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.0661916
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.020873893
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8244bc36b1d379643b2924571e4c6551, type: 3}
+--- !u!4 &3791432928286983059 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 2503884249544351018}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4370221605869430038 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2168958278646429756, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 2503884249544351018}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2512389591921433663
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1027021662347591207}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -7648,16 +7926,7 @@ PrefabInstance:
       value: -0.61582834
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &6358024386067518713 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 2512389591921433663}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7576209178589438235 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -7675,7 +7944,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4378509195466400251}
     m_Modifications:
     - target: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
@@ -7749,13 +8017,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2683079692176128305}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4456c9511fe6bd44f8848187c8c60661, type: 3}
 --- !u!114 &1056645006610527601 stripped
 MonoBehaviour:
@@ -7780,7 +8041,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102771577861391}
     m_Modifications:
     - target: {fileID: 1423533570973707283, guid: 805ff09ecbdb64b49893a439d2a0dd5a,
@@ -7854,13 +8114,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1781756651794368778}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4816384566778064424, guid: 805ff09ecbdb64b49893a439d2a0dd5a,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3000018961360714984}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 805ff09ecbdb64b49893a439d2a0dd5a, type: 3}
 --- !u!4 &7386139242445085141 stripped
 Transform:
@@ -7885,7 +8138,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8683238100874698455}
     m_Modifications:
     - target: {fileID: 387682593278930941, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
@@ -7924,13 +8176,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 748964538091476508, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3704810414420579624}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5, type: 3}
 --- !u!114 &2383364404914786551 stripped
 MonoBehaviour:
@@ -7955,7 +8200,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1060513094057905011}
     m_Modifications:
     - target: {fileID: 1616665003291586338, guid: 69263daf76bbb9241bdc86c6eba3f042,
@@ -7994,13 +8238,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7576209178589438235}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2883681095385756355, guid: 69263daf76bbb9241bdc86c6eba3f042,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6358024386067518713}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69263daf76bbb9241bdc86c6eba3f042, type: 3}
 --- !u!4 &1027021662347591207 stripped
 Transform:
@@ -8025,7 +8262,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3321089477655472406}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -8475,9 +8711,6 @@ PrefabInstance:
       value: 0.11629827
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &1811105238867002433 stripped
 MonoBehaviour:
@@ -8491,18 +8724,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &3704810414420579624 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 2823936905799681675}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3088728275966254802
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 149411600586214224}
     m_Modifications:
     - target: {fileID: 518162736366091525, guid: d3d177408c15bd64a8cc11c6cb2107da,
@@ -8541,13 +8767,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4041941474405525933}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
 --- !u!114 &3309508301370008535 stripped
 MonoBehaviour:
@@ -8572,7 +8791,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7817992716929427254}
     m_Modifications:
     - target: {fileID: 1035519807211317339, guid: 80095f3f054271f42917a02bbee04753,
@@ -8611,13 +8829,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5288163446442898062, guid: 80095f3f054271f42917a02bbee04753,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 9189810641016111410}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 80095f3f054271f42917a02bbee04753, type: 3}
 --- !u!114 &2674338350751021367 stripped
 MonoBehaviour:
@@ -8642,7 +8853,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7248215998017058309}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -8748,7 +8958,7 @@ PrefabInstance:
     - target: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
         type: 3}
@@ -9092,9 +9302,6 @@ PrefabInstance:
       value: 0.11585258
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &1557237745115711052 stripped
 MonoBehaviour:
@@ -9108,18 +9315,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4599332548383037221 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
+--- !u!1001 &3155103374408024891
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 3404765203270880376}
+    m_Modifications:
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.00000005960463
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.000000029802315
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Right
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d02b3151a5cba244299ff36e1b341b0e, type: 3}
+--- !u!114 &3240849616094887486 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 518162736366091525, guid: d02b3151a5cba244299ff36e1b341b0e,
     type: 3}
-  m_PrefabInstance: {fileID: 3138620003402237062}
+  m_PrefabInstance: {fileID: 3155103374408024891}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &7665561845243386164 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 3155103374408024891}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3192311670913808910
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7743368017229333725}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -9569,9 +9861,6 @@ PrefabInstance:
       value: 0.11585258
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &1323965605101746372 stripped
 MonoBehaviour:
@@ -9585,18 +9874,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4041941474405525933 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
+--- !u!1001 &3196289017675265982
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4806222123587879980}
+    m_Modifications:
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.010315023
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.003470488
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.052893806
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95141727
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.29998064
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.06619169
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.020869968
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Right
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d02b3151a5cba244299ff36e1b341b0e, type: 3}
+--- !u!114 &3128767737442454203 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 518162736366091525, guid: d02b3151a5cba244299ff36e1b341b0e,
     type: 3}
-  m_PrefabInstance: {fileID: 3192311670913808910}
+  m_PrefabInstance: {fileID: 3196289017675265982}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &7922915598243933617 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 3196289017675265982}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3204467164528408200
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 777868783899611809}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -10071,16 +10445,7 @@ PrefabInstance:
       value: -0.3807086
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &6240156831613763150 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 3204467164528408200}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7458342471418989484 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -10098,7 +10463,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4687052697666617737}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -10568,16 +10932,7 @@ PrefabInstance:
       value: -0.6386371
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &6277429000056855808 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 3313549889078629830}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7351509631126743266 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -10595,7 +10950,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4757642101461030966}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -11065,16 +11419,7 @@ PrefabInstance:
       value: -0.7155714
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &6072276412570749094 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 3361091882775838816}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7304038547213827396 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -11092,7 +11437,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 587980010454834534}
     m_Modifications:
     - target: {fileID: 4410372304194013889, guid: 29e9effd445553f44b5c72ab453724a2,
@@ -11166,13 +11510,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6259505418955565762}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4410372304194013889, guid: 29e9effd445553f44b5c72ab453724a2,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7477695455896887072}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29e9effd445553f44b5c72ab453724a2, type: 3}
 --- !u!4 &1440190724186639468 stripped
 Transform:
@@ -11197,7 +11534,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2794318493382213131}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -11647,9 +11983,6 @@ PrefabInstance:
       value: 0.1164646
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &1113586668021508184 stripped
 MonoBehaviour:
@@ -11663,18 +11996,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &2683079692176128305 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 3559730560886794898}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3723553215777363431
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102771787782018}
     m_Modifications:
     - target: {fileID: 2035611581279011425, guid: 16d5a85387d1508488672bb0b44e34d8,
@@ -11748,13 +12074,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7625513250253921243, guid: 16d5a85387d1508488672bb0b44e34d8,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2256674007353355741}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 16d5a85387d1508488672bb0b44e34d8, type: 3}
 --- !u!114 &3428160816063633286 stripped
 MonoBehaviour:
@@ -11779,7 +12098,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6643812793657114343}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -12229,9 +12547,6 @@ PrefabInstance:
       value: 0.11453576
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &743610863022034258 stripped
 MonoBehaviour:
@@ -12245,18 +12560,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &2313057784527871035 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 3765892311381626776}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3899715141823616259
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1269254892640704105}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -12711,9 +13019,6 @@ PrefabInstance:
       value: 0.11585258
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &579952232658753481 stripped
 MonoBehaviour:
@@ -12727,18 +13032,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &2469116725768046240 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 3899715141823616259}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4209036453194862726
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102771955918067}
     m_Modifications:
     - target: {fileID: 1592665250863918, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
@@ -12795,13 +13093,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7877366598363085799}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4828405532353868, guid: 2f6885b60be4f324a97d1aaf9a80649e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7842699756559581347}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
 --- !u!4 &4213301285867222474 stripped
 Transform:
@@ -12814,7 +13105,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102772382676977}
     m_Modifications:
     - target: {fileID: 5252699733111167308, guid: 1fb5ef83a52cd8c438d7a0900d315041,
@@ -12883,9 +13173,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1fb5ef83a52cd8c438d7a0900d315041, type: 3}
 --- !u!4 &8464126488652444146 stripped
 Transform:
@@ -12898,7 +13185,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102772005728716}
     m_Modifications:
     - target: {fileID: 4068415635407894754, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70,
@@ -12972,13 +13258,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1200794793149882648}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4068415635407894754, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2428060208701215994}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70, type: 3}
 --- !u!4 &509222119225189333 stripped
 Transform:
@@ -13003,7 +13282,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102772217217072}
     m_Modifications:
     - target: {fileID: 520104185047483028, guid: 6b1a3f41bc148c149822a7aa4b7cea6c,
@@ -13077,13 +13355,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7173017888739765419, guid: 6b1a3f41bc148c149822a7aa4b7cea6c,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4999085776818125137}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b1a3f41bc148c149822a7aa4b7cea6c, type: 3}
 --- !u!114 &274056329258486656 stripped
 MonoBehaviour:
@@ -13108,7 +13379,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102773436849566}
     m_Modifications:
     - target: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
@@ -13182,13 +13452,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 320890456431823628}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4456c9511fe6bd44f8848187c8c60661, type: 3}
 --- !u!4 &4729000470985783860 stripped
 Transform:
@@ -13213,7 +13476,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4459583609491229790}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -13683,9 +13945,6 @@ PrefabInstance:
       value: -0.51862484
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &189886725038449088 stripped
 MonoBehaviour:
@@ -13699,18 +13958,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &3727497927879906338 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 5285902039455866084}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5537764810887650938
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 777868783899611809}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -14190,16 +14442,7 @@ PrefabInstance:
       value: -0.112029
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &6377260999974014425 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 5537764810887650938}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8271110271609068720 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -14217,7 +14460,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6854757899467992511}
     m_Modifications:
     - target: {fileID: 1218532872865719490, guid: d2cb74c24cfc9ee47895c79bd63588b8,
@@ -14291,13 +14533,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 743610863022034258}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1218532872865719490, guid: d2cb74c24cfc9ee47895c79bd63588b8,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2313057784527871035}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d2cb74c24cfc9ee47895c79bd63588b8, type: 3}
 --- !u!114 &3657174080687002740 stripped
 MonoBehaviour:
@@ -14322,7 +14557,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8020760588509249827}
     m_Modifications:
     - target: {fileID: 518162736366091525, guid: d3d177408c15bd64a8cc11c6cb2107da,
@@ -14396,13 +14630,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2469116725768046240}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
 --- !u!4 &1269254892640704105 stripped
 Transform:
@@ -14427,7 +14654,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2329352064670148167}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -14877,16 +15103,7 @@ PrefabInstance:
       value: 0.066013955
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &4999085776818125137 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 5853220262141045490}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8009693615687411768 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -14904,7 +15121,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7386139242445085141}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -15374,9 +15590,6 @@ PrefabInstance:
       value: -0.3264336
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &1781756651794368778 stripped
 MonoBehaviour:
@@ -15390,18 +15603,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &3000018961360714984 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 5999855879889466414}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6072517653442780031
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5547079642152758336}
     m_Modifications:
     - target: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
@@ -15475,13 +15681,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7304038547213827396}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6072276412570749094}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e468af470a9a84469c1fafd8a98d3aa, type: 3}
 --- !u!114 &142183776959589310 stripped
 MonoBehaviour:
@@ -15506,7 +15705,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102773376192594}
     m_Modifications:
     - target: {fileID: 1650814283496127989, guid: 67fec7f25522717409503fca99db346e,
@@ -15580,13 +15778,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5066311812244101763, guid: 67fec7f25522717409503fca99db346e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1939866728374571307}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 67fec7f25522717409503fca99db346e, type: 3}
 --- !u!4 &1368918004222371822 stripped
 Transform:
@@ -15611,7 +15802,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1224446796210753952}
     m_Modifications:
     - target: {fileID: 2723120734780836270, guid: b1bcbbdc13bf97b4680f5fd80544212f,
@@ -15685,13 +15875,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4026061855515458856, guid: b1bcbbdc13bf97b4680f5fd80544212f,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5360321765451319743}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b1bcbbdc13bf97b4680f5fd80544212f, type: 3}
 --- !u!4 &6980667503537774855 stripped
 Transform:
@@ -15716,7 +15899,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2821985838646307844}
     m_Modifications:
     - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
@@ -15790,13 +15972,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 9013887584232872076}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
 --- !u!114 &5102426142897208786 stripped
 MonoBehaviour:
@@ -15821,7 +15996,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 509222119225189333}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -16291,9 +16465,6 @@ PrefabInstance:
       value: -0.3496437
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
 --- !u!114 &1200794793149882648 stripped
 MonoBehaviour:
@@ -16307,18 +16478,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &2428060208701215994 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 6580818567647419452}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6789513888917346844
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6980667503537774855}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -16768,16 +16932,7 @@ PrefabInstance:
       value: 0.11646467
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
---- !u!4 &5360321765451319743 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 6789513888917346844}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6929852155552979158 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4472907005493379786, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -16795,7 +16950,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5533574498610670303}
     m_Modifications:
     - target: {fileID: 4747887020954079553, guid: 3a5246b8e9a3ff94d8decc677270ca2b,
@@ -16869,13 +17023,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6491143446805225563, guid: 3a5246b8e9a3ff94d8decc677270ca2b,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3727497927879906338}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3a5246b8e9a3ff94d8decc677270ca2b, type: 3}
 --- !u!114 &2744188814160887108 stripped
 MonoBehaviour:
@@ -16900,7 +17047,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4788944244125391263}
     m_Modifications:
     - target: {fileID: 576766574486362294, guid: 1362aaa05ae8971458d3663d76e77388,
@@ -16974,13 +17120,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6013489660084081871, guid: 1362aaa05ae8971458d3663d76e77388,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1534645383472097235}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1362aaa05ae8971458d3663d76e77388, type: 3}
 --- !u!4 &4265126645085916260 stripped
 Transform:
@@ -17005,7 +17144,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4213301285867222474}
     m_Modifications:
     - target: {fileID: 1861925084399802, guid: d5365bf27c177624e86d490843374cc5, type: 3}
@@ -17061,16 +17199,7 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d5365bf27c177624e86d490843374cc5, type: 3}
---- !u!4 &7842699756559581347 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4997568335476448, guid: d5365bf27c177624e86d490843374cc5,
-    type: 3}
-  m_PrefabInstance: {fileID: 7838265163951552067}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7877366598363085799 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114027654286658980, guid: d5365bf27c177624e86d490843374cc5,
@@ -17088,7 +17217,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2366923889143389482}
     m_Modifications:
     - target: {fileID: 1616665003291586338, guid: 69263daf76bbb9241bdc86c6eba3f042,
@@ -17162,13 +17290,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4498504298371810406}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2883681095385756355, guid: 69263daf76bbb9241bdc86c6eba3f042,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1114010573679817092}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69263daf76bbb9241bdc86c6eba3f042, type: 3}
 --- !u!114 &45082022574237964 stripped
 MonoBehaviour:
@@ -17193,7 +17314,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8670577416213706627}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -17663,16 +17783,7 @@ PrefabInstance:
       value: -0.47870815
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &1540011271966643462 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 8052093551185862080}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2614092683242152164 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -17690,7 +17801,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8085127552405452350}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -18140,9 +18250,6 @@ PrefabInstance:
       value: 0.11629827
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &5674864294467572832 stripped
 MonoBehaviour:
@@ -18156,18 +18263,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &7244423649895712009 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 8130086098451011242}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8160939669790899315
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3743783497526393327}
     m_Modifications:
     - target: {fileID: 61187928742045460, guid: d24f101e55f1044499abdf9e7d8009ff,
@@ -18617,9 +18717,6 @@ PrefabInstance:
       value: 0.11883362
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d24f101e55f1044499abdf9e7d8009ff, type: 3}
 --- !u!114 &5716068883028098745 stripped
 MonoBehaviour:
@@ -18633,18 +18730,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &7285691365885554640 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1466628484531655587, guid: d24f101e55f1044499abdf9e7d8009ff,
-    type: 3}
-  m_PrefabInstance: {fileID: 8160939669790899315}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8206831277658173210
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4208149788106692293}
     m_Modifications:
     - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
@@ -18683,13 +18773,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 13792968909884555}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
 --- !u!4 &7477928993898623395 stripped
 Transform:
@@ -18714,7 +18797,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8775979619116044218}
     m_Modifications:
     - target: {fileID: 1861925084399802, guid: d5365bf27c177624e86d490843374cc5, type: 3}
@@ -18770,16 +18852,7 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d5365bf27c177624e86d490843374cc5, type: 3}
---- !u!4 &8403931223137279748 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4997568335476448, guid: d5365bf27c177624e86d490843374cc5,
-    type: 3}
-  m_PrefabInstance: {fileID: 8408506003301673444}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8440898147967493184 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114027654286658980, guid: d5365bf27c177624e86d490843374cc5,
@@ -18797,7 +18870,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102771955918067}
     m_Modifications:
     - target: {fileID: 3497850108274224814, guid: b04572deff2238441ae1d1261ac11cb7,
@@ -18866,9 +18938,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b04572deff2238441ae1d1261ac11cb7, type: 3}
 --- !u!4 &2926045479182968129 stripped
 Transform:
@@ -18881,7 +18950,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5024159597714144136}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -19351,16 +19419,7 @@ PrefabInstance:
       value: -0.61582834
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &1114010573679817092 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 8472452655295772994}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4498504298371810406 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -19378,7 +19437,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102773193171258}
     m_Modifications:
     - target: {fileID: 1022174075519953592, guid: 85ec652e6760cde4caa8c21c04899b32,
@@ -19452,13 +19510,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1022174075519953592, guid: 85ec652e6760cde4caa8c21c04899b32,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1540011271966643462}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 85ec652e6760cde4caa8c21c04899b32, type: 3}
 --- !u!114 &7967033227431221713 stripped
 MonoBehaviour:
@@ -19483,7 +19534,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102772382676977}
     m_Modifications:
     - target: {fileID: 1592665250863918, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
@@ -19550,13 +19600,6 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4828405532353868, guid: 2f6885b60be4f324a97d1aaf9a80649e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8403931223137279748}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
 --- !u!4 &8775979619116044218 stripped
 Transform:
@@ -19569,7 +19612,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3618055453928691680}
     m_Modifications:
     - target: {fileID: 387682593278930941, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
@@ -19643,13 +19685,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 748964538091476508, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7244423649895712009}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5, type: 3}
 --- !u!4 &8085127552405452350 stripped
 Transform:
@@ -19674,7 +19709,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7477928993898623395}
     m_Modifications:
     - target: {fileID: 145954230530673830, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -20149,16 +20183,7 @@ PrefabInstance:
       value: -0.61582893
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1200971ce776ca54da8091edaff1ebea, type: 3}
---- !u!4 &13792968909884555 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8854622757335255238, guid: 1200971ce776ca54da8091edaff1ebea,
-    type: 3}
-  m_PrefabInstance: {fileID: 8849838087737132109}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3542406306708486505 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5474643347140066596, guid: 1200971ce776ca54da8091edaff1ebea,
@@ -20176,7 +20201,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4171102772270682432}
     m_Modifications:
     - target: {fileID: 1118677525653310923, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
@@ -20255,17 +20279,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 8194672666024225992, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6240156831613763150}
-    - targetCorrespondingSourceObject: {fileID: 8194672666024225992, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6377260999974014425}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 110dfd2b03610494ca8d739b4dfbb0cb, type: 3}
 --- !u!4 &777868783899611809 stripped
 Transform:
@@ -20290,7 +20303,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1713394206075963707}
     m_Modifications:
     - target: {fileID: 1304256556020238828, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
@@ -20306,7 +20318,7 @@ PrefabInstance:
     - target: {fileID: 2256169275208995370, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2256169275208995370, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
         type: 3}
@@ -20329,13 +20341,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1557237745115711052}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2256169275208995370, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4599332548383037221}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea, type: 3}
 --- !u!114 &1289474599117920135 stripped
 MonoBehaviour:

--- a/Runtime/Prefabs/HandIntegrations/SmallHandsIntegration.prefab
+++ b/Runtime/Prefabs/HandIntegrations/SmallHandsIntegration.prefab
@@ -30,7 +30,7 @@ Transform:
   m_Children:
   - {fileID: 8001708670561560772}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 13.475, y: -34.987, z: -81.147}
 --- !u!1 &563414087671150470
 GameObject:
@@ -77,6 +77,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85e5b3a94d5599c4982fe887142e1201, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 3064399650386795987}
   _rightHandSensor: {fileID: 1336493790961484724}
   _updateAvatarLeftHand: 1
@@ -279,6 +280,38 @@ Transform:
   m_Children:
   - {fileID: 5654735148976513950}
   m_Father: {fileID: 3128986662380031212}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1513424965603734921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 582336984439538553}
+  m_Layer: 0
+  m_Name: SensorLeftMetaTouchQuest3SteamVR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &582336984439538553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513424965603734921}
+  m_LocalRotation: {x: 0.14708765, y: -0.27855524, z: -0.73836315, w: 0.5963155}
+  m_LocalPosition: {x: -0.124467805, y: -0.0043486953, z: 0.084506586}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1390686559638004739}
+  m_Father: {fileID: 5531240989471681271}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1640501058931475994
@@ -396,7 +429,7 @@ Transform:
   m_Children:
   - {fileID: 6373326380962342719}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 13
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: -7.6920004, y: -46.296, z: -97.33301}
 --- !u!1 &2035600255179323854
 GameObject:
@@ -460,7 +493,7 @@ Transform:
   m_Children:
   - {fileID: 7861936303558514986}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 10
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 13.475, y: -34.987, z: -81.147}
 --- !u!1 &2136154509580579274
 GameObject:
@@ -499,7 +532,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7376297068528982650
 MonoBehaviour:
@@ -513,6 +546,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c997e1e44845a44599cad72e2f63768, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 2814310393973123227}
   _rightHandSensor: {fileID: 2756803127438523629}
   _updateAvatarLeftHand: 1
@@ -549,6 +583,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1d9733f867143cc499549d95ef911b9b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 3554103018363445916}
   _rightHandSensor: {fileID: 2230148109603670788}
   _updateAvatarLeftHand: 1
@@ -585,6 +620,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9f2ab5b48994c7b933178d3fea37f60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 7590497890982095155}
   _rightHandSensor: {fileID: 3481585515279718008}
   _updateAvatarLeftHand: 1
@@ -628,6 +664,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6d431e33dfaa8a49b2c2572cdf2c202, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 4565025461854159825}
   _rightHandSensor: {fileID: 1556505065565409921}
   _updateAvatarLeftHand: 1
@@ -689,7 +726,7 @@ Transform:
   m_Children:
   - {fileID: 2417261773784224133}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 8
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 13.475, y: -34.987, z: -81.147}
 --- !u!1 &2392665997810963919
 GameObject:
@@ -721,7 +758,7 @@ Transform:
   m_Children:
   - {fileID: 1630373758340084758}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 7
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 5.9560003, y: -60.022003, z: -446.575}
 --- !u!1 &2592013792655908661
 GameObject:
@@ -753,7 +790,7 @@ Transform:
   m_Children:
   - {fileID: 7662793729792359213}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2897251039130523002
 GameObject:
@@ -785,7 +822,7 @@ Transform:
   m_Children:
   - {fileID: 2245657520410724522}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 13
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 7.7400002, y: -46.818, z: -446.558}
 --- !u!1 &3448794302029330973
 GameObject:
@@ -818,7 +855,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: -1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &624641232835354594
 MonoBehaviour:
@@ -832,6 +869,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 207d5725f18c1eb4eaba95a17cdf1794, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 8307217609931264530}
   _rightHandSensor: {fileID: 8004981803011213754}
   _updateAvatarLeftHand: 1
@@ -1024,7 +1062,7 @@ Transform:
   m_Children:
   - {fileID: 5167676817864274365}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 7
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: -5.9560003, y: -60.022003, z: -93.425}
 --- !u!1 &4018593808129346126
 GameObject:
@@ -1075,6 +1113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9f613010cce8f0408243773fe913d9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 3404041426145428164}
   _rightHandSensor: {fileID: 262689289843351157}
   _updateAvatarLeftHand: 1
@@ -1118,6 +1157,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7aaab42f00bf7ad4bb5388a08c575a4d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 464095179920767179}
   _rightHandSensor: {fileID: 113979628159394627}
   _updateAvatarLeftHand: 1
@@ -1161,6 +1201,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74d5790b838df3441b94784597d32e7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 5285633823444224781}
   _rightHandSensor: {fileID: 3592344487797175698}
   _updateAvatarLeftHand: 1
@@ -1214,7 +1255,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4230562510541276347
 GameObject:
@@ -1247,7 +1288,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4142930980535561806
 MonoBehaviour:
@@ -1261,6 +1302,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c210797670b3ccb4faa0d527c28face7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 4284657614020466222}
   _rightHandSensor: {fileID: 3627141910175385680}
   _updateAvatarLeftHand: 1
@@ -1354,7 +1396,7 @@ Transform:
   m_Children:
   - {fileID: 7911844508476582540}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 12
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 7.102, y: -49.612003, z: -86.247}
 --- !u!1 &4733975975006882423
 GameObject:
@@ -1387,7 +1429,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9086594797314180850
 MonoBehaviour:
@@ -1401,6 +1443,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6e44a53324016f44da8b9fb0183ace63, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 5079607265924657314}
   _rightHandSensor: {fileID: 5135971961843093241}
   _updateAvatarLeftHand: 1
@@ -1456,7 +1499,7 @@ Transform:
   m_Children:
   - {fileID: 3041540576091668094}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 10
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5019676455976106501
 GameObject:
@@ -1537,7 +1580,7 @@ Transform:
   m_Children:
   - {fileID: 5248089203358912506}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5180033630438516948
 GameObject:
@@ -1601,8 +1644,40 @@ Transform:
   m_Children:
   - {fileID: 358287252001097817}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: -1
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5379012466651812316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3381040898413932704}
+  m_Layer: 0
+  m_Name: SensorRightMetaTouchQuest3SteamVR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3381040898413932704
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5379012466651812316}
+  m_LocalRotation: {x: 0.27915668, y: -0.15397532, z: -0.58926797, w: 0.74237895}
+  m_LocalPosition: {x: -0.12308105, y: 0.004379913, z: 0.08540437}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7264488151711586523}
+  m_Father: {fileID: 3128986662380031212}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 13.475, y: -34.987, z: -81.147}
 --- !u!1 &5432498020235686207
 GameObject:
   m_ObjectHideFlags: 0
@@ -1665,7 +1740,7 @@ Transform:
   m_Children:
   - {fileID: 1729208719835598632}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 11
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6060265445443236015
 GameObject:
@@ -1703,6 +1778,8 @@ Transform:
   - {fileID: 8004981803011213754}
   - {fileID: 4645468440740339549}
   - {fileID: 2667085520663634660}
+  - {fileID: 1206225939715524629}
+  - {fileID: 3381040898413932704}
   - {fileID: 2756803127438523629}
   - {fileID: 3481585515279718008}
   - {fileID: 2230148109603670788}
@@ -1775,7 +1852,7 @@ Transform:
   m_Children:
   - {fileID: 1686254330736947178}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: -1
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7029085866834886021
 GameObject:
@@ -1839,7 +1916,7 @@ Transform:
   m_Children:
   - {fileID: 6579339044925100716}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 8
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7129598433673619899
 GameObject:
@@ -1871,7 +1948,7 @@ Transform:
   m_Children:
   - {fileID: 5521868987826942675}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 11
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7130254118803436632
 GameObject:
@@ -1903,7 +1980,7 @@ Transform:
   m_Children:
   - {fileID: 5854462388332400899}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 9
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7513607983792556249
 GameObject:
@@ -1936,6 +2013,38 @@ Transform:
   - {fileID: 4804900499501360946}
   m_Father: {fileID: 3128986662380031212}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7766961318284555013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1206225939715524629}
+  m_Layer: 0
+  m_Name: SensorRightMetaTouchQuest3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1206225939715524629
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7766961318284555013}
+  m_LocalRotation: {x: 0.45103756, y: -0.36509863, z: -0.52613974, w: 0.6216471}
+  m_LocalPosition: {x: -0.10010181, y: 0.02629718, z: 0.040715575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 244619243894931468}
+  m_Father: {fileID: 3128986662380031212}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7919614609563926060
 GameObject:
@@ -1999,7 +2108,7 @@ Transform:
   m_Children:
   - {fileID: 7247816104762979542}
   m_Father: {fileID: 5531240989471681271}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8014021478637372587
 GameObject:
@@ -2064,6 +2173,10 @@ GameObject:
   - component: {fileID: 6664634404192452015}
   - component: {fileID: 8774188962597412380}
   - component: {fileID: 4171035829969326594}
+  - component: {fileID: 1644632009472595981}
+  - component: {fileID: 3836946984288462148}
+  - component: {fileID: 1277873304964022672}
+  - component: {fileID: 1712453497857705746}
   m_Layer: 0
   m_Name: Meta
   m_TagString: Untagged
@@ -2084,7 +2197,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7487040073430986574
 MonoBehaviour:
@@ -2098,6 +2211,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 793d8fce02a8c7a42a9414fb6f5d3dc1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 7689936855456343885}
   _rightHandSensor: {fileID: 4645468440740339549}
   _updateAvatarLeftHand: 1
@@ -2134,6 +2248,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 813e0bb28152bed4ea5c634099e04934, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 7625526473525729595}
   _rightHandSensor: {fileID: 2667085520663634660}
   _updateAvatarLeftHand: 1
@@ -2154,6 +2269,87 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _leftController: {fileID: 7831389305533026899}
   _rightController: {fileID: 2995883073837649870}
+  _controller: {fileID: 0}
+  _enableObjectListLeft: []
+  _enableObjectListRight: []
+  _enableObjectList: []
+  _openHandPoseName: 
+  _indexCurlAmount: 60
+  _middleCurlAmount: 60
+  _ringCurlAmount: 60
+  _littleCurlAmount: 60
+  _thumbCurlAmount: 60
+  _thumbSpreadAmount: 30
+--- !u!114 &1644632009472595981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8064071124950283855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cc855f608e72a745b7a79e8ca93ba67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
+  _leftHandSensor: {fileID: 620278235831248989}
+  _rightHandSensor: {fileID: 1206225939715524629}
+  _updateAvatarLeftHand: 1
+  _updateAvatarRightHand: 1
+  _smoothPosition: 0
+  _smoothRotation: 0
+--- !u!114 &3836946984288462148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8064071124950283855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd07cb58266720f478deb9264c45c614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leftController: {fileID: 8730255253275241365}
+  _rightController: {fileID: 5043270190144153350}
+  _controller: {fileID: 0}
+  _enableObjectListLeft: []
+  _enableObjectListRight: []
+  _enableObjectList: []
+--- !u!114 &1277873304964022672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8064071124950283855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07ea441b9add1fd4fb72713dd14725cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
+  _leftHandSensor: {fileID: 582336984439538553}
+  _rightHandSensor: {fileID: 3381040898413932704}
+  _updateAvatarLeftHand: 1
+  _updateAvatarRightHand: 1
+  _smoothPosition: 0
+  _smoothRotation: 0
+--- !u!114 &1712453497857705746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8064071124950283855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0acc555071f36c4fb74251d9a25c5ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leftController: {fileID: 1979177291694228102}
+  _rightController: {fileID: 2470471855816015825}
   _controller: {fileID: 0}
   _enableObjectListLeft: []
   _enableObjectListRight: []
@@ -2250,6 +2446,8 @@ Transform:
   - {fileID: 8307217609931264530}
   - {fileID: 7689936855456343885}
   - {fileID: 7625526473525729595}
+  - {fileID: 620278235831248989}
+  - {fileID: 582336984439538553}
   - {fileID: 2814310393973123227}
   - {fileID: 7590497890982095155}
   - {fileID: 3554103018363445916}
@@ -2291,7 +2489,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7230639067285797868}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2316401944124808782
 MonoBehaviour:
@@ -2305,6 +2503,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91427e7abc5228c44af202060dafa3af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hideAvatarInPassthrough: 1
   _leftHandSensor: {fileID: 5039997878117545930}
   _rightHandSensor: {fileID: 4004456319755097366}
   _updateAvatarLeftHand: 1
@@ -2329,6 +2528,38 @@ MonoBehaviour:
   _enableObjectListLeft: []
   _enableObjectListRight: []
   _enableObjectList: []
+--- !u!1 &8980668123825819757
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 620278235831248989}
+  m_Layer: 0
+  m_Name: SensorLeftMetaTouchQuest3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &620278235831248989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8980668123825819757}
+  m_LocalRotation: {x: 0.3651, y: -0.4510359, z: -0.62164736, w: 0.5261399}
+  m_LocalPosition: {x: -0.10010181, y: -0.026297182, z: 0.040715575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8148099871281450256}
+  m_Father: {fileID: 5531240989471681271}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9185323946395759302
 GameObject:
   m_ObjectHideFlags: 0
@@ -2359,14 +2590,13 @@ Transform:
   m_Children:
   - {fileID: 3219060853486873977}
   m_Father: {fileID: 3128986662380031212}
-  m_RootOrder: 12
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &158010435924872381
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4565025461854159825}
     m_Modifications:
     - target: {fileID: 1616665003291586338, guid: 69263daf76bbb9241bdc86c6eba3f042,
@@ -2440,13 +2670,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 214071357853755461}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2883681095385756355, guid: 69263daf76bbb9241bdc86c6eba3f042,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8226963111186269255}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69263daf76bbb9241bdc86c6eba3f042, type: 3}
 --- !u!4 &3041540576091668094 stripped
 Transform:
@@ -2471,7 +2694,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2245657520410724522}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -2921,9 +3143,6 @@ PrefabInstance:
       value: 0.05215118
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
 --- !u!114 &3555100670809115525 stripped
 MonoBehaviour:
@@ -2937,18 +3156,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4288627863189428449 stripped
+--- !u!1001 &391464977428953786
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 582336984439538553}
+    m_Modifications:
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.010107087
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.003302414
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.05366592
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.952087
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.30019122
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.055739038
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.017574279
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8244bc36b1d379643b2924571e4c6551, type: 3}
+--- !u!4 &1390686559638004739 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
+  m_CorrespondingSourceObject: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
     type: 3}
-  m_PrefabInstance: {fileID: 325193051930854305}
+  m_PrefabInstance: {fileID: 391464977428953786}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1979177291694228102 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2168958278646429756, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 391464977428953786}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &448824752070696152
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3041540576091668094}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -3403,9 +3707,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &214071357853755461 stripped
 MonoBehaviour:
@@ -3419,18 +3720,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8226963111186269255 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 448824752070696152}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &511964146956338647
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1722130555642164577}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -3880,9 +4174,6 @@ PrefabInstance:
       value: 0.05215109
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
 --- !u!114 &3661370212487695859 stripped
 MonoBehaviour:
@@ -3896,18 +4187,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4043609761926454935 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 511964146956338647}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &588073114327432640
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8004981803011213754}
     m_Modifications:
     - target: {fileID: 1304256556020238828, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
@@ -3981,13 +4265,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8903871891206896252}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2256169275208995370, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8161346229856626968}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9b7b4c4c81d00f248bfa345f09bcf8ea, type: 3}
 --- !u!4 &1686254330736947178 stripped
 Transform:
@@ -4012,7 +4289,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7833134397781290293}
     m_Modifications:
     - target: {fileID: 3497850108274224814, guid: b04572deff2238441ae1d1261ac11cb7,
@@ -4086,9 +4362,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b04572deff2238441ae1d1261ac11cb7, type: 3}
 --- !u!4 &6107981235721753153 stripped
 Transform:
@@ -4101,7 +4374,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1920256501415895311}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -4556,9 +4828,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &951303829582554509 stripped
 MonoBehaviour:
@@ -4572,18 +4841,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &9072279702395799951 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 716554704558641424}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &766238633779280653
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2417261773784224133}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -5033,16 +5295,7 @@ PrefabInstance:
       value: 0.05215115
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &3865545264930758733 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 766238633779280653}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4573169682316473129 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -5060,7 +5313,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3259816006604939416}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -5515,9 +5767,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &703273997772273340 stripped
 MonoBehaviour:
@@ -5531,18 +5780,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8725166146611403454 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 936894435434349089}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &964432119011498773
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7861936303558514986}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -5997,16 +6239,7 @@ PrefabInstance:
       value: 0.05215116
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &3631393256800272469 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 964432119011498773}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4086816026203738929 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -6024,7 +6257,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1729208719835598632}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -6469,16 +6701,7 @@ PrefabInstance:
       value: 0.052151285
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &3674594045276217170 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 1007067829373518866}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4047824260849159222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -6496,7 +6719,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 358287252001097817}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -6893,7 +7115,7 @@ PrefabInstance:
     - target: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
         type: 3}
@@ -6951,9 +7173,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &759818077372364662 stripped
 MonoBehaviour:
@@ -6967,18 +7186,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8818022903833844596 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 1029470520402625515}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1278166966004730020
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7911844508476582540}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -7433,9 +7645,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &1548945159704493113 stripped
 MonoBehaviour:
@@ -7449,18 +7658,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &7325798529707429947 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 1278166966004730020}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1287008769299533916
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7247816104762979542}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -7915,9 +8117,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &1521755805874889921 stripped
 MonoBehaviour:
@@ -7931,18 +8130,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &7334920476541241539 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 1287008769299533916}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1340588119875916499
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2756803127438523629}
     m_Modifications:
     - target: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
@@ -8016,13 +8208,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6970200800066812139}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4456c9511fe6bd44f8848187c8c60661, type: 3}
 --- !u!4 &1630373758340084758 stripped
 Transform:
@@ -8047,7 +8232,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5039997878117545930}
     m_Modifications:
     - target: {fileID: 4747887020954079553, guid: 3a5246b8e9a3ff94d8decc677270ca2b,
@@ -8086,13 +8270,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6491143446805225563, guid: 3a5246b8e9a3ff94d8decc677270ca2b,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1455343541631724159}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3a5246b8e9a3ff94d8decc677270ca2b, type: 3}
 --- !u!4 &5521868987826942675 stripped
 Transform:
@@ -8117,7 +8294,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8001708670561560772}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -8562,16 +8738,7 @@ PrefabInstance:
       value: 0.052151337
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &2765974376437286236 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 1830046945379130908}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3220269871070418488 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -8589,7 +8756,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5079607265924657314}
     m_Modifications:
     - target: {fileID: 1423533570973707283, guid: 805ff09ecbdb64b49893a439d2a0dd5a,
@@ -8663,13 +8829,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3747026632069533590}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4816384566778064424, guid: 805ff09ecbdb64b49893a439d2a0dd5a,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4959764216926675860}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 805ff09ecbdb64b49893a439d2a0dd5a, type: 3}
 --- !u!114 &5100133852755499814 stripped
 MonoBehaviour:
@@ -8694,7 +8853,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8307217609931264530}
     m_Modifications:
     - target: {fileID: 1304256556020238828, guid: 829a78814902e734baf523f5584385ef,
@@ -8768,13 +8926,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 759818077372364662}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2256169275208995370, guid: 829a78814902e734baf523f5584385ef,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8818022903833844596}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 829a78814902e734baf523f5584385ef, type: 3}
 --- !u!4 &358287252001097817 stripped
 Transform:
@@ -8799,7 +8950,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5654735148976513950}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -9254,16 +9404,7 @@ PrefabInstance:
       value: 0.05215116
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &2429638346471975016 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 2211507378453295912}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3127128015873129228 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -9281,7 +9422,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6579339044925100716}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -9736,9 +9876,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &2641039068576550248 stripped
 MonoBehaviour:
@@ -9752,18 +9889,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &6085023431552295274 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 2334228506600929781}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2456702057936578622
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7662793729792359213}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -10208,9 +10338,6 @@ PrefabInstance:
       value: 0.052151337
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
 --- !u!114 &1712183573853823002 stripped
 MonoBehaviour:
@@ -10224,18 +10351,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &2094420715317752702 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 2456702057936578622}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2509619254058719725
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3404041426145428164}
     m_Modifications:
     - target: {fileID: 4068415635407894754, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70,
@@ -10309,13 +10429,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 951303829582554509}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4068415635407894754, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 9072279702395799951}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: beb6d8e2e2b8a3b4a8020af6c4c49b70, type: 3}
 --- !u!4 &1920256501415895311 stripped
 Transform:
@@ -10340,7 +10453,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4004456319755097366}
     m_Modifications:
     - target: {fileID: 3648587437342829609, guid: b4ed1ff5000a874458e5227176282a5d,
@@ -10379,13 +10491,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 3648587437342829609, guid: b4ed1ff5000a874458e5227176282a5d,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3674594045276217170}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4ed1ff5000a874458e5227176282a5d, type: 3}
 --- !u!4 &1729208719835598632 stripped
 Transform:
@@ -10405,12 +10510,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &2699911632656696020
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 3381040898413932704}
+    m_Modifications:
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.0106429905
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0052221827
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.05352529
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.95366126
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.2954323
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.056416616
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.008192739
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Right
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d02b3151a5cba244299ff36e1b341b0e, type: 3}
+--- !u!114 &2470471855816015825 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 518162736366091525, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2699911632656696020}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &7264488151711586523 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2699911632656696020}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2716004036366088000
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3481585515279718008}
     m_Modifications:
     - target: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
@@ -10484,13 +10680,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 304830258852046533, guid: 4456c9511fe6bd44f8848187c8c60661,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3865545264930758733}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4456c9511fe6bd44f8848187c8c60661, type: 3}
 --- !u!114 &713057560540093183 stripped
 MonoBehaviour:
@@ -10515,7 +10704,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7705929155377405966}
     m_Modifications:
     - target: {fileID: 1861925084399802, guid: d5365bf27c177624e86d490843374cc5, type: 3}
@@ -10571,16 +10759,7 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d5365bf27c177624e86d490843374cc5, type: 3}
---- !u!4 &2777776445803547424 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4997568335476448, guid: d5365bf27c177624e86d490843374cc5,
-    type: 3}
-  m_PrefabInstance: {fileID: 2782491980380323264}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2812636758701961316 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114027654286658980, guid: d5365bf27c177624e86d490843374cc5,
@@ -10598,7 +10777,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4804900499501360946}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -11043,9 +11221,6 @@ PrefabInstance:
       value: 0.05215133
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
 --- !u!114 &1349402622438585372 stripped
 MonoBehaviour:
@@ -11059,18 +11234,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1758673116047189880 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 2841519489851964472}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2995167722520973210
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 734260775164077647}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -11525,9 +11693,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &3265947915519195911 stripped
 MonoBehaviour:
@@ -11541,18 +11706,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &6739207806140258053 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 2995167722520973210}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3170270681621471522
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4645468440740339549}
     m_Modifications:
     - target: {fileID: 518162736366091525, guid: d3d177408c15bd64a8cc11c6cb2107da,
@@ -11626,13 +11784,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2094420715317752702}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
 --- !u!114 &3229065678024858663 stripped
 MonoBehaviour:
@@ -11657,7 +11808,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3592344487797175698}
     m_Modifications:
     - target: {fileID: 1218532872865719490, guid: d2cb74c24cfc9ee47895c79bd63588b8,
@@ -11731,13 +11881,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5322306188413331741}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1218532872865719490, guid: d2cb74c24cfc9ee47895c79bd63588b8,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4831979972611963513}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d2cb74c24cfc9ee47895c79bd63588b8, type: 3}
 --- !u!4 &4332808578618263399 stripped
 Transform:
@@ -11762,7 +11905,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2667085520663634660}
     m_Modifications:
     - target: {fileID: 518162736366091525, guid: d3d177408c15bd64a8cc11c6cb2107da,
@@ -11836,13 +11978,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4731214129627339279, guid: d3d177408c15bd64a8cc11c6cb2107da,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2765974376437286236}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3d177408c15bd64a8cc11c6cb2107da, type: 3}
 --- !u!114 &2995883073837649870 stripped
 MonoBehaviour:
@@ -11867,7 +12002,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8131029290281375403}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -12322,9 +12456,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &3804974648953543898 stripped
 MonoBehaviour:
@@ -12338,18 +12469,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4907093804316324056 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 3463267252220520519}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3513405437406362379
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6373326380962342719}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -12799,9 +12923,6 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
 --- !u!114 &3747026632069533590 stripped
 MonoBehaviour:
@@ -12815,18 +12936,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4959764216926675860 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 3513405437406362379}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3825415102089251744
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 262689289843351157}
     m_Modifications:
     - target: {fileID: 520104185047483028, guid: 6b1a3f41bc148c149822a7aa4b7cea6c,
@@ -12900,13 +13014,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7173017888739765419, guid: 6b1a3f41bc148c149822a7aa4b7cea6c,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 360247882673272611}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b1a3f41bc148c149822a7aa4b7cea6c, type: 3}
 --- !u!4 &6241205164220016395 stripped
 Transform:
@@ -12931,7 +13038,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5285633823444224781}
     m_Modifications:
     - target: {fileID: 4905336985384385113, guid: 288a93c0145c91e42b6c0eaf63f1705c,
@@ -13005,13 +13111,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4905336985384385113, guid: 288a93c0145c91e42b6c0eaf63f1705c,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4051690468897315151}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 288a93c0145c91e42b6c0eaf63f1705c, type: 3}
 --- !u!114 &8198663966902922202 stripped
 MonoBehaviour:
@@ -13036,7 +13135,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6241205164220016395}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -13491,16 +13589,7 @@ PrefabInstance:
       value: 0.052151203
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &360247882673272611 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 4321430892505443427}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1021717756262261831 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -13513,12 +13602,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &4813690249180486147
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1206225939715524629}
+    m_Modifications:
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Right
+      objectReference: {fileID: 0}
+    - target: {fileID: 9100977399721758085, guid: d02b3151a5cba244299ff36e1b341b0e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d02b3151a5cba244299ff36e1b341b0e, type: 3}
+--- !u!4 &244619243894931468 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4731214129627339279, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4813690249180486147}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5043270190144153350 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 518162736366091525, guid: d02b3151a5cba244299ff36e1b341b0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4813690249180486147}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4851444330504082625
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3064399650386795987}
     m_Modifications:
     - target: {fileID: 1035519807211317339, guid: 80095f3f054271f42917a02bbee04753,
@@ -13592,13 +13772,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5288163446442898062, guid: 80095f3f054271f42917a02bbee04753,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6739207806140258053}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 80095f3f054271f42917a02bbee04753, type: 3}
 --- !u!4 &734260775164077647 stripped
 Transform:
@@ -13623,7 +13796,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2230148109603670788}
     m_Modifications:
     - target: {fileID: 387682593278930941, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
@@ -13697,13 +13869,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 748964538091476508, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2429638346471975016}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5, type: 3}
 --- !u!114 &4718698928279231103 stripped
 MonoBehaviour:
@@ -13728,7 +13893,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5854462388332400899}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -14183,16 +14347,7 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
---- !u!4 &3468310399099375543 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 4915513005842569000}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4680764446701380533 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 342840369402541213, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -14210,7 +14365,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1336493790961484724}
     m_Modifications:
     - target: {fileID: 576766574486362294, guid: 1362aaa05ae8971458d3663d76e77388,
@@ -14284,13 +14438,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6013489660084081871, guid: 1362aaa05ae8971458d3663d76e77388,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4043609761926454935}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1362aaa05ae8971458d3663d76e77388, type: 3}
 --- !u!4 &1722130555642164577 stripped
 Transform:
@@ -14315,7 +14462,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 9042561896569371885}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -14770,16 +14916,7 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
---- !u!4 &4051690468897315151 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 5489043402008183248}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5255415560883189069 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 342840369402541213, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -14797,7 +14934,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7590497890982095155}
     m_Modifications:
     - target: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
@@ -14871,13 +15007,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2641039068576550248}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6085023431552295274}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e468af470a9a84469c1fafd8a98d3aa, type: 3}
 --- !u!114 &1779250796469592356 stripped
 MonoBehaviour:
@@ -14902,7 +15031,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3259816006604939416}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -15357,16 +15485,7 @@ PrefabInstance:
       value: 0.052150227
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &8253839680683225492 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 5588002312503798484}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8672105622022300400 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -15384,7 +15503,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 464095179920767179}
     m_Modifications:
     - target: {fileID: 4410372304194013889, guid: 29e9effd445553f44b5c72ab453724a2,
@@ -15458,13 +15576,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3804974648953543898}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4410372304194013889, guid: 29e9effd445553f44b5c72ab453724a2,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4907093804316324056}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29e9effd445553f44b5c72ab453724a2, type: 3}
 --- !u!114 &4156106098090911897 stripped
 MonoBehaviour:
@@ -15489,7 +15600,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1686254330736947178}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -15701,7 +15811,7 @@ PrefabInstance:
     - target: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
         type: 3}
@@ -15934,16 +16044,7 @@ PrefabInstance:
       value: 0.052151337
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &8161346229856626968 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 5640186983049327192}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8903871891206896252 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -15961,7 +16062,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3219060853486873977}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -16406,9 +16506,6 @@ PrefabInstance:
       value: 0.052151177
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
 --- !u!114 &7347765542824976729 stripped
 MonoBehaviour:
@@ -16422,18 +16519,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e3aec586ed72f74a8f71a9fc93449d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8010360832227226173 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 5777434108517362045}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5905387096321553140
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2814310393973123227}
     m_Modifications:
     - target: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
@@ -16507,13 +16597,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8808834241001192394}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1604232446582833993, guid: 1e468af470a9a84469c1fafd8a98d3aa,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 786941956966651848}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e468af470a9a84469c1fafd8a98d3aa, type: 3}
 --- !u!114 &308759921446011445 stripped
 MonoBehaviour:
@@ -16538,7 +16621,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6680608105242929401}
     m_Modifications:
     - target: {fileID: 1861925084399802, guid: d5365bf27c177624e86d490843374cc5, type: 3}
@@ -16594,16 +16676,7 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d5365bf27c177624e86d490843374cc5, type: 3}
---- !u!4 &6055718518305477475 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4997568335476448, guid: d5365bf27c177624e86d490843374cc5,
-    type: 3}
-  m_PrefabInstance: {fileID: 6060713337685681539}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6165112498852325415 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114027654286658980, guid: d5365bf27c177624e86d490843374cc5,
@@ -16621,7 +16694,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8473470935904033839}
     m_Modifications:
     - target: {fileID: 5252699733111167308, guid: 1fb5ef83a52cd8c438d7a0900d315041,
@@ -16695,9 +16767,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1fb5ef83a52cd8c438d7a0900d315041, type: 3}
 --- !u!4 &2046918690435886521 stripped
 Transform:
@@ -16710,7 +16779,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5964662842488715389}
     m_Modifications:
     - target: {fileID: 1118677525653310923, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
@@ -16789,17 +16857,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 8194672666024225992, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8725166146611403454}
-    - targetCorrespondingSourceObject: {fileID: 8194672666024225992, guid: 110dfd2b03610494ca8d739b4dfbb0cb,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8253839680683225492}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 110dfd2b03610494ca8d739b4dfbb0cb, type: 3}
 --- !u!4 &3259816006604939416 stripped
 Transform:
@@ -16824,7 +16881,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7833134397781290293}
     m_Modifications:
     - target: {fileID: 1592665250863918, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
@@ -16890,13 +16946,6 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4828405532353868, guid: 2f6885b60be4f324a97d1aaf9a80649e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6055718518305477475}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
 --- !u!4 &6680608105242929401 stripped
 Transform:
@@ -16909,7 +16958,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7689936855456343885}
     m_Modifications:
     - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
@@ -16983,13 +17031,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 544867218707957054}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
 --- !u!114 &4679011449108113791 stripped
 MonoBehaviour:
@@ -17014,7 +17055,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1630373758340084758}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -17464,16 +17504,7 @@ PrefabInstance:
       value: 0.05215115
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &6970200800066812139 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 6898447797874074539}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7667701459249212303 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -17491,7 +17522,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5521868987826942675}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -17946,16 +17976,7 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
---- !u!4 &1455343541631724159 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 6927921448842277600}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7270754448080324221 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 342840369402541213, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -17973,7 +17994,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4284657614020466222}
     m_Modifications:
     - target: {fileID: 1022174075519953592, guid: 85ec652e6760cde4caa8c21c04899b32,
@@ -18047,13 +18067,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1022174075519953592, guid: 85ec652e6760cde4caa8c21c04899b32,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7325798529707429947}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 85ec652e6760cde4caa8c21c04899b32, type: 3}
 --- !u!4 &7911844508476582540 stripped
 Transform:
@@ -18073,12 +18086,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &7435910234057053097
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 620278235831248989}
+    m_Modifications:
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000014901161
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_Name
+      value: MetaTouchQuest3Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 7850569591709463420, guid: 8244bc36b1d379643b2924571e4c6551,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8244bc36b1d379643b2924571e4c6551, type: 3}
+--- !u!4 &8148099871281450256 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1594966257726824121, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 7435910234057053097}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8730255253275241365 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2168958278646429756, guid: 8244bc36b1d379643b2924571e4c6551,
+    type: 3}
+  m_PrefabInstance: {fileID: 7435910234057053097}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2285bc0022316448ac5c40fd488b38a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7457941391802683190
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 1556505065565409921}
     m_Modifications:
     - target: {fileID: 387682593278930941, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
@@ -18152,13 +18256,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 748964538091476508, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3631393256800272469}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b07ac2ce480eed4ba4870b7c7f69ef5, type: 3}
 --- !u!114 &7070296741671264459 stripped
 MonoBehaviour:
@@ -18183,7 +18280,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 8473470935904033839}
     m_Modifications:
     - target: {fileID: 1592665250863918, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
@@ -18259,13 +18355,6 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4828405532353868, guid: 2f6885b60be4f324a97d1aaf9a80649e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2777776445803547424}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2f6885b60be4f324a97d1aaf9a80649e, type: 3}
 --- !u!4 &7705929155377405966 stripped
 Transform:
@@ -18278,7 +18367,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3627141910175385680}
     m_Modifications:
     - target: {fileID: 1650814283496127989, guid: 67fec7f25522717409503fca99db346e,
@@ -18352,13 +18440,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5066311812244101763, guid: 67fec7f25522717409503fca99db346e,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8010360832227226173}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 67fec7f25522717409503fca99db346e, type: 3}
 --- !u!4 &3219060853486873977 stripped
 Transform:
@@ -18383,7 +18464,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7625526473525729595}
     m_Modifications:
     - target: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
@@ -18457,13 +18537,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1594966257726824121, guid: 26e99b1cbf818624f85b4832cb2b6dff,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7334920476541241539}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 26e99b1cbf818624f85b4832cb2b6dff, type: 3}
 --- !u!4 &7247816104762979542 stripped
 Transform:
@@ -18488,7 +18561,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5248089203358912506}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -18943,16 +19015,7 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
---- !u!4 &544867218707957054 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 8329760723223993761}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8600540761594964284 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 342840369402541213, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -18970,7 +19033,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 113979628159394627}
     m_Modifications:
     - target: {fileID: 2723120734780836270, guid: b1bcbbdc13bf97b4680f5fd80544212f,
@@ -19044,13 +19106,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 4026061855515458856, guid: b1bcbbdc13bf97b4680f5fd80544212f,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1758673116047189880}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b1bcbbdc13bf97b4680f5fd80544212f, type: 3}
 --- !u!4 &4804900499501360946 stripped
 Transform:
@@ -19075,7 +19130,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5135971961843093241}
     m_Modifications:
     - target: {fileID: 2035611581279011425, guid: 16d5a85387d1508488672bb0b44e34d8,
@@ -19149,13 +19203,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7625513250253921243, guid: 16d5a85387d1508488672bb0b44e34d8,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4288627863189428449}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 16d5a85387d1508488672bb0b44e34d8, type: 3}
 --- !u!4 &2245657520410724522 stripped
 Transform:
@@ -19180,7 +19227,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 3554103018363445916}
     m_Modifications:
     - target: {fileID: 1616665003291586338, guid: 69263daf76bbb9241bdc86c6eba3f042,
@@ -19254,13 +19300,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4680764446701380533}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2883681095385756355, guid: 69263daf76bbb9241bdc86c6eba3f042,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3468310399099375543}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69263daf76bbb9241bdc86c6eba3f042, type: 3}
 --- !u!114 &1451977477875680135 stripped
 MonoBehaviour:
@@ -19285,7 +19324,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 4332808578618263399}
     m_Modifications:
     - target: {fileID: 110800317558027184, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -19735,16 +19773,7 @@ PrefabInstance:
       value: 0.052150793
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92fd9fda79d08cf428e33d60a51fc0ab, type: 3}
---- !u!4 &4831979972611963513 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541621883278990144, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
-    type: 3}
-  m_PrefabInstance: {fileID: 8937869709939466553}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5322306188413331741 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3879024671027824676, guid: 92fd9fda79d08cf428e33d60a51fc0ab,
@@ -19762,7 +19791,6 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 5167676817864274365}
     m_Modifications:
     - target: {fileID: 276551217321664757, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
@@ -20217,16 +20245,7 @@ PrefabInstance:
       value: SmallControllerHandLeft
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0c05f7bfc05e7b4f8d9344bf65fd618, type: 3}
---- !u!4 &786941956966651848 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8365015090047719583, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,
-    type: 3}
-  m_PrefabInstance: {fileID: 9150548554799550295}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8808834241001192394 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 342840369402541213, guid: d0c05f7bfc05e7b4f8d9344bf65fd618,

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Input.cs
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Input.cs
@@ -1,0 +1,72 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UxrMetaTouchQuest3Input.cs" company="VRMADA">
+//   Copyright (c) VRMADA, All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+using UltimateXR.Core;
+
+namespace UltimateXR.Devices.Integrations.Meta
+{
+    /// <summary>
+    ///     Oculus Touch controller input using Oculus SDK.
+    /// </summary>
+    public class UxrMetaTouchQuest3Input : UxrUnityXRControllerInput
+    {
+        #region Public Overrides UxrControllerInput
+
+        /// <summary>
+        ///     Gets the SDK dependency: Oculus SDK.
+        /// </summary>
+        public override string SDKDependency => UxrManager.SdkOculus;
+
+        /// <inheritdoc />
+        public override UxrControllerSetupType SetupType => UxrControllerSetupType.Dual;
+
+        /// <inheritdoc />
+        public override bool IsHandednessSupported => true;
+
+        /// <inheritdoc />
+        public override bool MainJoystickIsTouchpad => false;
+
+        /// <inheritdoc />
+        public override bool HasControllerElements(UxrHandSide handSide, UxrControllerElements controllerElements)
+        {
+            uint validElements = (uint)(UxrControllerElements.Joystick |
+                                        UxrControllerElements.Grip |
+                                        UxrControllerElements.Trigger |
+                                        UxrControllerElements.ThumbCapSense |
+                                        UxrControllerElements.Button1 |
+                                        UxrControllerElements.Button2 |
+                                        UxrControllerElements.Menu |
+                                        UxrControllerElements.DPad);
+
+            if (handSide == UxrHandSide.Right)
+            {
+                // Remove menu button from right controller, which is reserved.
+                validElements = validElements & ~(uint)UxrControllerElements.Menu;
+            }
+
+            return (validElements & (uint)controllerElements) == (uint)controllerElements;
+        }
+
+        #endregion
+
+        #region Public Overrides UxrUnityXRControllerInput
+
+        /// <inheritdoc />
+        public override IEnumerable<string> ControllerNames
+        {
+            get
+            {
+                if (UxrTrackingDevice.HeadsetDeviceName is "Oculus Quest3" or "Meta Quest 3")
+                {
+                    yield return "Oculus Touch Controller - Left";
+                    yield return "Oculus Touch Controller - Right";
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Input.cs.meta
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Input.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fd07cb58266720f478deb9264c45c614
+timeCreated: 1499677449
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3InputSteamVR.cs
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3InputSteamVR.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="UxrMetaTouchQuest2InputSteamVR.cs" company="VRMADA">
+// <copyright file="UxrMetaTouchQuest3InputSteamVR.cs" company="VRMADA">
 //   Copyright (c) VRMADA, All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -12,7 +12,7 @@ namespace UltimateXR.Devices.Integrations.Meta
     /// <summary>
     ///     Oculus Touch controllers input using SteamVR.
     /// </summary>
-    public class UxrMetaTouchQuest2InputSteamVR : UxrSteamVRControllerInput
+    public class UxrMetaTouchQuest3InputSteamVR : UxrSteamVRControllerInput
     {
         #region Public Overrides UxrSteamVRControllerInput
 
@@ -21,8 +21,10 @@ namespace UltimateXR.Devices.Integrations.Meta
         {
             get
             {
-                yield return "Oculus Quest2 (Left Controller)";
-                yield return "Oculus Quest2 (Right Controller)";
+                yield return "Oculus Quest3 (Left Controller)";
+                yield return "Oculus Quest3 (Right Controller)";
+                yield return "Meta Quest 3 (Left Controller)";
+                yield return "Meta Quest 3 (Right Controller)";
             }
         }
 

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3InputSteamVR.cs.meta
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3InputSteamVR.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a0acc555071f36c4fb74251d9a25c5ae
+timeCreated: 1499677449
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Tracking.cs
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Tracking.cs
@@ -1,22 +1,29 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="UxrMetaTouchQuest2TrackingSteamVR.cs" company="VRMADA">
+// <copyright file="UxrMetaTouchQuest3Tracking.cs" company="VRMADA">
 //   Copyright (c) VRMADA, All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 using System;
-using UltimateXR.Devices.Integrations.SteamVR;
+using UltimateXR.Core;
 
 namespace UltimateXR.Devices.Integrations.Meta
 {
     /// <summary>
-    ///     Tracking for Oculus Touch controllers using SteamVR SDK.
+    ///     Tracking for Oculus Touch devices using the Oculus SDK.
     /// </summary>
-    public class UxrMetaTouchQuest2TrackingSteamVR : UxrSteamVRControllerTracking
+    public class UxrMetaTouchQuest3Tracking : UxrUnityXRControllerTracking
     {
         #region Public Overrides UxrControllerTracking
 
         /// <inheritdoc />
-        public override Type RelatedControllerInputType => typeof(UxrMetaTouchQuest2InputSteamVR);
+        public override Type RelatedControllerInputType => typeof(UxrMetaTouchQuest3Input);
+
+        #endregion
+
+        #region Public Overrides UxrTrackingDevice
+
+        /// <inheritdoc />
+        public override string SDKDependency => UxrManager.SdkOculus;
 
         #endregion
     }

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Tracking.cs.meta
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3Tracking.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6cc855f608e72a745b7a79e8ca93ba67
+timeCreated: 1499842642
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3TrackingSteamVR.cs
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3TrackingSteamVR.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="UxrMetaTouchQuest2TrackingSteamVR.cs" company="VRMADA">
+// <copyright file="UxrMetaTouchQuest3TrackingSteamVR.cs" company="VRMADA">
 //   Copyright (c) VRMADA, All rights reserved.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
@@ -11,12 +11,12 @@ namespace UltimateXR.Devices.Integrations.Meta
     /// <summary>
     ///     Tracking for Oculus Touch controllers using SteamVR SDK.
     /// </summary>
-    public class UxrMetaTouchQuest2TrackingSteamVR : UxrSteamVRControllerTracking
+    public class UxrMetaTouchQuest3TrackingSteamVR : UxrSteamVRControllerTracking
     {
         #region Public Overrides UxrControllerTracking
 
         /// <inheritdoc />
-        public override Type RelatedControllerInputType => typeof(UxrMetaTouchQuest2InputSteamVR);
+        public override Type RelatedControllerInputType => typeof(UxrMetaTouchQuest3InputSteamVR);
 
         #endregion
     }

--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3TrackingSteamVR.cs.meta
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest3TrackingSteamVR.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 07ea441b9add1fd4fb72713dd14725cb
+timeCreated: 1624443263


### PR DESCRIPTION
Added Quest 3 components and assets for Oculus and SteamVR platforms.
Integrated Quest 3 components and assets into BigHandsIntegration and SmallHandsIntegration.
Changed namespaces in Quest2 SteamVR components from Oculus to Meta.
