### PR TITLE
Fix Pico input not working after using home button

### DIFF
--- a/Runtime/Scripts/Avatar/UxrAvatar.cs
+++ b/Runtime/Scripts/Avatar/UxrAvatar.cs
@@ -175,8 +175,16 @@ namespace UltimateXR.Avatar
         {
             get
             {
-                UxrControllerInput controllerInput = UxrControllerInput.GetComponents(this).FirstOrDefault(i => i.GetType() != typeof(UxrDummyControllerInput));
+                // First look for a controller that is not dummy nor gamepad:
+                UxrControllerInput controllerInput = UxrControllerInput.GetComponents(this).FirstOrDefault(i => i.GetType() != typeof(UxrDummyControllerInput) && i.GetType() != typeof(UxrGamepadInput));
 
+                // No controllers found? Try gamepad
+                if (controllerInput == null)
+                {
+                    controllerInput = UxrControllerInput.GetComponents(this).FirstOrDefault(i => i.GetType() == typeof(UxrGamepadInput));    
+                }
+
+                // No controllers found? Return dummy to avoid null reference exceptions.
                 if (controllerInput == null)
                 {
                     UxrDummyControllerInput inputDummy = gameObject.GetOrAddComponent<UxrDummyControllerInput>();


### PR DESCRIPTION
Pico seems to report a gamepad controller after using the home button.
To fix it, we give priority of any other controller over the gamepad.