### PR TITLE
Fix UxrLaserPointer hit quad position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix UxrLaserPointer hit quad position using controller forward.
 - Fix Pico controllers not working after using home button.
 - Fix Valve Index controllers' forward vectors.
 - Fix laser pointers not working correctly when mixing UI with 2D/3D objects.

--- a/Runtime/Scripts/UI/UxrLaserPointer.cs
+++ b/Runtime/Scripts/UI/UxrLaserPointer.cs
@@ -356,7 +356,7 @@ namespace UltimateXR.UI
                 if (Avatar.CameraComponent && _hitQuad)
                 {
                     _hitQuad.SetActive(true);
-                    _hitQuad.transform.localPosition = Vector3.forward * CurrentRayLength;
+                    _hitQuad.transform.position = LaserTransform.TransformPoint(Vector3.forward * CurrentRayLength);
                     _hitQuad.transform.LookAt(Avatar.CameraPosition);
 
                     Plane plane = new Plane(Avatar.CameraForward, Avatar.CameraPosition);


### PR DESCRIPTION
Fix UxrLaserPointer hit quad position when using the controller's forward transform instead of the laser pointer's own transform.