### PR TITLE
Quest 3 support for Android builds

### DIFF
--- a/Runtime/Scripts/Devices/UxrTrackingDevice.cs
+++ b/Runtime/Scripts/Devices/UxrTrackingDevice.cs
@@ -42,6 +42,16 @@ namespace UltimateXR.Devices
         {
             get
             {
+                #if UNITY_ANDROID && !UNITY_EDITOR
+                var androidDeviceNameMappings = new Dictionary<string, string> {
+                    { "Quest 3", "Meta Quest 3" }
+                };
+
+                if (androidDeviceNameMappings.TryGetValue(SystemInfo.deviceName, out var deviceName)) {
+                    return deviceName;
+                }
+                #endif
+
                 var inputDevices = new List<InputDevice>();
                 InputDevices.GetDevices(inputDevices);
 


### PR DESCRIPTION
Issue: Current solution for fetching `HeadsetDeviceName` fails to return correct value for Quest 3 when built for the device. That value being `Oculus Headset2`.

Context: Unity 2022.3.16, Meta All-in-one 60, XR Management 4.4.0

Solution: For Android builds only, map device name (fetched from SystemInfo) to the correct value manually, if present in the mapping dictionary.

Note: Since this is somewhat of a workaround, I kept the changes very minimal. I would like to hear your suggestions for potentially better way of mapping the values and maybe better separation of concerns.