### PR TITLE
Updated new SDK link and branding from Oculus to Meta.

### DIFF
--- a/Editor/Sdks/InputTracking/UxrSdkLocatorOvr.cs
+++ b/Editor/Sdks/InputTracking/UxrSdkLocatorOvr.cs
@@ -23,7 +23,7 @@ namespace UltimateXR.Editor.Sdks.InputTracking
         public override string Name => UxrConstants.SdkOculus;
 
         /// <inheritdoc />
-        public override string MinimumUnityVersion => "2021.1";
+        public override string MinimumUnityVersion => "2021.3";
 
         /// <inheritdoc />
         public override string[] AvailableSymbols
@@ -72,7 +72,7 @@ namespace UltimateXR.Editor.Sdks.InputTracking
         {
             if (EditorUtility.DisplayDialog("Install integration?", $"Oculus integration asset needs to be installed. Proceed to the Asset Store?", UxrConstants.Editor.Yes, UxrConstants.Editor.Cancel))
             {
-                Application.OpenURL("https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022");
+                Application.OpenURL("https://assetstore.unity.com/packages/tools/integration/meta-xr-core-sdk-269169");
             }
         }
 
@@ -102,7 +102,7 @@ namespace UltimateXR.Editor.Sdks.InputTracking
         /// <summary>
         ///     Allows to remove dependencies from the project in case the user removed SDK folders manually.
         /// </summary>
-        [MenuItem(UxrConstants.Editor.MenuPathSdksInputTracking + "Remove Symbols for Oculus SDK", priority = UxrConstants.Editor.PriorityMenuPathSdksInputTracking)]
+        [MenuItem(UxrConstants.Editor.MenuPathSdksInputTracking + "Remove Symbols for Meta XR Core SDK", priority = UxrConstants.Editor.PriorityMenuPathSdksInputTracking)]
         private static void RemoveSymbols()
         {
             UxrSdkManager.RemoveSymbols(new UxrSdkLocatorOvr());

--- a/Runtime/Scripts/Core/UxrConstants.SDKs.cs
+++ b/Runtime/Scripts/Core/UxrConstants.SDKs.cs
@@ -12,7 +12,7 @@ namespace UltimateXR.Core
         // Input/Tracking
         
         public const string SdkUnityInputSystem    = "Unity Input System";
-        public const string SdkOculus              = "Oculus";
+        public const string SdkOculus              = "Meta Quest";
         public const string SdkSteamVR             = "SteamVR";
         public const string SdkWindowsMixedReality = "Windows Mixed Reality";
         public const string SdkUltraleap           = "Ultraleap";


### PR DESCRIPTION
The original "Oculus Integration" package has been deprecated since the release of the Quest 3.

However, luckily the people over at Meta have really thought about backward compatibility and hence we're able to just replace the Oculus Integration with the Meta XR Core SDK package without any technical changes to UltimateXR or our code.