### PR TITLE
Add a TryGetLaserHitPosition method to UxrLaserPointer

### DIFF
--- a/Runtime/Scripts/UI/UnityInputModule/UxrPointerInputModule.cs
+++ b/Runtime/Scripts/UI/UnityInputModule/UxrPointerInputModule.cs
@@ -896,7 +896,8 @@ namespace UltimateXR.UI.UnityInputModule
 
             data.button           = PointerEventData.InputButton.Left;
             data.useDragThreshold = true;
-
+            data.PreviousWorldPos = data.WorldPos;
+            
             // Raycast
 
             RaycastResult raycastResult = data.pointerCurrentRaycast;
@@ -994,6 +995,17 @@ namespace UltimateXR.UI.UnityInputModule
             if (data.pointerCurrentRaycast.gameObject == null && data.pointerEnter != null)
             {
                 data.ReleasedThisFrame = true;
+            }
+
+            if (raycast.isValid)
+            {
+                data.WorldPos = laserPointer.LaserPos + laserPointer.LaserDir * raycast.distance;
+
+                if (!data.WorldPosInitialized && raycast.isValid)
+                {
+                    data.PreviousWorldPos = data.WorldPos;
+                    data.WorldPosInitialized = true;
+                }
             }
 
             return data;

--- a/Runtime/Scripts/UI/UxrFingerTip.cs
+++ b/Runtime/Scripts/UI/UxrFingerTip.cs
@@ -78,6 +78,17 @@ namespace UltimateXR.UI
             return box != null && transform.position.IsInsideBox(box);
         }
 
+        /// <summary>
+        ///     Tries to get the pointer event data.
+        /// </summary>
+        /// <param name="pointerEventData">Returns the pointer event data</param>
+        /// <returns>True if the event data was returned, false otherwise</returns>
+        public bool TryGetPointerEventData(out UxrPointerEventData pointerEventData)
+        {
+            pointerEventData = UxrPointerInputModule.Instance.GetFingerTipPointerEventData(this);
+            return eventData.HasData;
+        }
+
         #endregion
 
         #region Unity

--- a/Runtime/Scripts/UI/UxrLaserPointer.cs
+++ b/Runtime/Scripts/UI/UxrLaserPointer.cs
@@ -231,7 +231,7 @@ namespace UltimateXR.UI
         }
 
         /// <summary>
-        ///     Gets or sets the size of the ray hit quad..
+        ///     Gets or sets the size of the ray hit quad.
         /// </summary>
         public float RayHitSize
         {
@@ -280,19 +280,36 @@ namespace UltimateXR.UI
         }
 
         /// <summary>
-        ///     Tries to get the position where the laser pointer hits an object.
+        ///     Tries to get the world position where the laser pointer hits an object.
         /// </summary>
-        /// <param name="hitPosition">The position where the laser pointer hits an object.</param>
-        /// <returns>True if the laser pointer is enabled and a hit position is calculated, false otherwise.</returns>
-        public bool TryGetLaserHitPosition(out Vector3 _hitPosition)
+        /// <param name="hitPosition">Returns the position where the laser pointer hits an object</param>
+        /// <returns>True if the laser pointer is enabled and a hit position is calculated, false otherwise</returns>
+        public bool TryGetLaserHitPosition(out Vector3 hitPosition)
         {
             if (IsLaserEnabled)
             {
-                _hitPosition = LaserPos + LaserDir * CurrentRayLength;
-                return true;
+                UxrPointerEventData eventData = UxrPointerInputModule.Instance.GetLaserPointerEventData(this);
+
+                if (eventData.HasData)
+                {
+                    hitPosition = eventData.pointerCurrentRaycast.WorldPos;
+                    return true;
+                }
             }
-            _hitPosition = Vector3.zero;
+            
+            hitPosition = Vector3.zero;
             return false;
+        }
+
+        /// <summary>
+        ///     Tries to get the pointer event data.
+        /// </summary>
+        /// <param name="pointerEventData">Returns the pointer event data</param>
+        /// <returns>True if the event data was returned, false otherwise</returns>
+        public bool TryGetPointerEventData(out UxrPointerEventData pointerEventData)
+        {
+            pointerEventData = UxrPointerInputModule.Instance.GetLaserPointerEventData(this);
+            return eventData.HasData;
         }
 
         #endregion


### PR DESCRIPTION
Uxr has a ton of methods for handling the laser pointer, but there isn't a method for getting the actual position of where the laser is hitting. This is what I came up with. I also tried to keep in line with UXR's coding style.